### PR TITLE
docs(jvm): add Java/Kotlin (Maven, Gradle) hardening guide

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -26,6 +26,8 @@ exclude = [
   "https://example.com",
   # claude.ai returns 403 for automated link checkers
   "https://claude.ai",
+  # medium.com returns 403 for automated link checkers
+  "https://medium.com",
 ]
 
 # Exclude paths from scanning

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: MIT
 
 # Package Manager Security Hardening
 
-A reference for hardening software supply chains across npm, pnpm, Yarn, Bun, pip, uv, Go modules, Cargo, Terraform, and OpenTofu.
+A reference for hardening software supply chains across npm, pnpm, Yarn, Bun, pip, uv, Go modules, Cargo, Maven, Gradle, Terraform, and OpenTofu.
 
 Supply chain attacks typically succeed through one of a small number of vectors: a loose version constraint allows a newly published malicious version to be silently pulled in; a missing or unenforced lockfile lets an attacker's package substitute for a legitimate one; a compromised maintainer account publishes a backdoored patch release that lands in CI within minutes of publication; or a package's postinstall script runs arbitrary code during a routine `npm install`. This repository addresses all of these through a layered set of controls applied consistently across ecosystems.
 
@@ -44,6 +44,7 @@ curl -o AGENTS.md https://raw.githubusercontent.com/jordanconway/package-manager
 curl -o AGENTS.md https://raw.githubusercontent.com/jordanconway/package-manager-hardening/main/agents/AGENTS-github-actions.md
 curl -o AGENTS.md https://raw.githubusercontent.com/jordanconway/package-manager-hardening/main/agents/AGENTS-docker.md
 curl -o AGENTS.md https://raw.githubusercontent.com/jordanconway/package-manager-hardening/main/agents/AGENTS-helm.md
+curl -o AGENTS.md https://raw.githubusercontent.com/jordanconway/package-manager-hardening/main/agents/AGENTS-jvm.md
 ```
 
 **For on-demand auditing:** install the `harden-packages` skill and say `harden my repo` in Claude Code or Cowork.
@@ -68,6 +69,7 @@ cp -r skills/harden-packages ~/.claude/skills/
 | [Ruby](docs/ruby.md) | Bundler — `Gemfile.lock`, exact pinning, `BUNDLE_FROZEN`, `bundler-audit`, Dependabot cooldown |
 | [Terraform / OpenTofu](docs/terraform.md) | Provider pinning, `.terraform.lock.hcl`, multi-platform hashes, `-lockfile=readonly`, OpenTofu differences |
 | [Helm](docs/helm.md) | `Chart.yaml` exact pinning, `Chart.lock`, `helm dependency build`, OCI digest pinning, `--verify` / cosign, Renovate cooldowns, Helmfile |
+| [JVM (Java/Kotlin)](docs/jvm.md) | Maven, Gradle — exact pinning, `<dependencyManagement>`, maven-enforcer, `gradle.lockfile`, dependency verification (`verification-metadata.xml`), Gradle Wrapper SHA pinning, repository control |
 
 ### Cross-cutting controls
 
@@ -101,6 +103,8 @@ cp -r skills/harden-packages ~/.claude/skills/
 | [Go modules](docs/go.md#go-modules) | ❌ No | — | (use Dependabot or proxy) | — |
 | [Composer](docs/php.md#composer) | ❌ No | — | (use Dependabot + exact pins) | — |
 | [Helm](docs/helm.md) | ❌ No | — | (use Renovate `minimumReleaseAge`; Dependabot does not support Helm chart deps) | — |
+| [Maven](docs/jvm.md#maven) | ❌ No | — | (use Dependabot + exact pins + maven-enforcer `banDynamicVersions`) | — |
+| [Gradle](docs/jvm.md#gradle) | ❌ No | — | (use Dependabot + `dependencyLocking` + `verification-metadata.xml`) | — |
 | [Bundler](docs/ruby.md#bundler) | ❌ No | — | (use Dependabot + exact pins) | — |
 | [Terraform](docs/terraform.md#terraform) / [OpenTofu](docs/terraform.md#opentofu) | ❌ No | — | (use exact `=` pins + Dependabot²) | — |
 
@@ -126,10 +130,14 @@ The lockfile provides a partial mitigation — it pins exact resolved versions �
 | [Bundler](docs/ruby.md#bundler) | `~>` (pessimistic) | `~> 7.1` `~> 7.1.3` `>= 7.1.0` | `7.1.3` | ✅ Yes — `BUNDLE_FROZEN=true` | Use bare version strings in `Gemfile` |
 | [Terraform](docs/terraform.md#terraform) / [OpenTofu](docs/terraform.md#opentofu) | `~>` (patch-only by default²) | `~> 5.0` `>= 5.0` `>= 5.0, < 6.0` | `= 5.31.0` | ✅ Yes — `.terraform.lock.hcl`; `-lockfile=readonly` | Use `= X.Y.Z` in `required_providers`; run `terraform providers lock` for multi-platform hashes |
 | [Helm](docs/helm.md) | None (user-specified, SemVer ranges accepted) | `^15.5.0` `~15.5` `>=15.0.0` `15.x.x` | `15.5.20` | ✅ Yes — `Chart.lock` digest; `helm dependency build` enforces it | Use bare exact versions in `Chart.yaml` `dependencies[].version`; never run `helm dependency update` in CI |
+| [Maven](docs/jvm.md#maven) | Soft requirement (exact unless overridden) | `[3.2,)` `[3.2,4.0)` `LATEST` `RELEASE` `3.2-SNAPSHOT` | `3.2.1` | ❌ No native lockfile³ | Pin every direct dep + transitive in `<dependencyManagement>`; enforce via `maven-enforcer-plugin` `banDynamicVersions` + `requirePluginVersions` |
+| [Gradle](docs/jvm.md#gradle) | Exact when written exact; dynamic syntax permitted | `1.+` `latest.release` `[1.2,2.0)` `1.2.3-SNAPSHOT` | `1.2.3` | ✅ Yes — `gradle.lockfile` with `LockMode.STRICT`; `gradle/verification-metadata.xml` adds SHA-256/PGP verification | `failOnNonReproducibleResolution()` + `dependencyLocking { lockAllConfigurations() }` + write verification metadata |
 
 **¹ Go's Minimum Version Selection (MVS)** works differently from other package managers. A `require` directive specifies the *minimum acceptable version*, and Go always resolves to that exact version (never newer) unless you explicitly run `go get -u`. This makes Go more conservative by default — it will not silently adopt new versions without an explicit developer action. However, `go get -u` and `go get @latest` bypass this safety and should be avoided in favour of pinning explicit tagged versions. The same rule applies to `go install` invocations in Makefiles and CI scripts — never use `@latest`; always pin `@vX.Y.Z`.
 
 **² Terraform and OpenTofu `~>` semantics:** The pessimistic constraint `~> 5.0` allows any `5.x` release (equivalent to `>= 5.0, < 6.0`), while `~> 5.31.0` allows only `5.31.x` patch releases. Neither form is as restrictive as exact pinning. Unlike other ecosystems there is also no native cooldown — the `.terraform.lock.hcl` lockfile records hashes of the resolved version but does not prevent automatic adoption of new versions when `terraform init -upgrade` is run or when Dependabot opens a PR. Exact pinning with `= 5.31.0` is the only reliable defence. Note: Dependabot cooldown for the `terraform` ecosystem is affected by a known bug (GitHub issue [#13715](https://github.com/dependabot/dependabot-core/issues/13715)) that may prevent provider updates from respecting cooldown days — use exact pinning as the primary control.
+
+**³ Maven has no native lockfile.** The `pom.xml` is the only manifest, and transitive versions are re-resolved on every build unless every direct *and* transitive coordinate is explicitly pinned in `<dependencyManagement>`. Combine this with `maven-enforcer-plugin` rules (`banDynamicVersions`, `requirePluginVersions`, `requireReleaseDeps`, `dependencyConvergence`) to fail the build on any unpinned or ranged dependency. Third-party plugins such as `io.github.chains-project:maven-lockfile` can add hash-based reproducibility if required. Maven also defaults to `warn` (not `fail`) on checksum mismatches — set `<checksumPolicy>fail</checksumPolicy>` or pass `--strict-checksums`.
 
 **Key observation:** For Node.js tools, Cargo, and uv, the lockfile is a strong control *only when actively enforced*. If CI runs `npm install` instead of `npm ci`, or if a developer installs a new dependency on a workstation without committing the updated lockfile, the loose constraint in the manifest becomes the effective policy. Exact pinning in the manifest eliminates this residual risk regardless of how install commands are invoked.
 
@@ -181,3 +189,16 @@ The lockfile provides a partial mitigation — it pins exact resolved versions �
 - [Docker Scout](https://docs.docker.com/scout/)
 - [Sigstore Cosign](https://docs.sigstore.dev/cosign/overview/)
 - [GoogleContainerTools/distroless](https://github.com/GoogleContainerTools/distroless)
+- [Maven Documentation](https://maven.apache.org/guides/)
+- [Maven Enforcer Plugin — Built-in Rules](https://maven.apache.org/enforcer/enforcer-rules/index.html)
+- [Maven Dependency Management](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html)
+- [maven-lockfile (chains-project)](https://github.com/chains-project/maven-lockfile)
+- [Gradle Documentation](https://docs.gradle.org/current/userguide/userguide.html)
+- [Gradle Dependency Locking](https://docs.gradle.org/current/userguide/dependency_locking.html)
+- [Gradle Dependency Verification](https://docs.gradle.org/current/userguide/dependency_verification.html)
+- [Gradle Version Catalogs](https://docs.gradle.org/current/userguide/platforms.html)
+- [Gradle Plugin Portal](https://plugins.gradle.org/)
+- [OWASP Dependency-Check](https://owasp.org/www-project-dependency-check/)
+- [CycloneDX Maven Plugin](https://github.com/CycloneDX/cyclonedx-maven-plugin)
+- [CycloneDX Gradle Plugin](https://github.com/CycloneDX/cyclonedx-gradle-plugin)
+- [Sonatype OSS Index](https://ossindex.sonatype.org/)

--- a/agents/AGENTS-jvm.md
+++ b/agents/AGENTS-jvm.md
@@ -176,7 +176,7 @@ Security update PRs from Dependabot bypass the cooldown automatically and should
 Every GitHub Actions workflow that runs `mvn` or `./gradlew` must include `step-security/harden-runner` as its first step. Start in `audit` mode for new workflows, then tighten to `block` once the egress policy is stable:
 
 ```yaml
-- uses: step-security/harden-runner@v2
+- uses: step-security/harden-runner@bb774aa972c2a89ff34781233d275075cbddf542 # v2
   with:
     egress-policy: block
     disable-sudo: true

--- a/agents/AGENTS-jvm.md
+++ b/agents/AGENTS-jvm.md
@@ -176,7 +176,7 @@ Security update PRs from Dependabot bypass the cooldown automatically and should
 Every GitHub Actions workflow that runs `mvn` or `./gradlew` must include `step-security/harden-runner` as its first step. Start in `audit` mode for new workflows, then tighten to `block` once the egress policy is stable:
 
 ```yaml
-- uses: step-security/harden-runner@bb774aa972c2a89ff34781233d275075cbddf542 # v2
+- uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2
   with:
     egress-policy: block
     disable-sudo: true

--- a/agents/AGENTS-jvm.md
+++ b/agents/AGENTS-jvm.md
@@ -1,0 +1,211 @@
+<!--
+SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+SPDX-License-Identifier: MIT
+-->
+
+# Agent Instructions: JVM (Java / Kotlin / Scala) Dependency Management
+
+This file contains mandatory guidelines for managing dependencies in this JVM project (Maven or Gradle). Follow these rules whenever adding, updating, or removing dependencies or plugins, or modifying CI configuration.
+
+## Dependency Rules — All JVM projects
+
+**Always pin exact versions** for both direct dependencies and plugins. Never use dynamic versions, ranges, `LATEST`, `RELEASE`, `+`, or `SNAPSHOT` in production manifests.
+
+**Never add a dependency or plugin version published within the last 7 days.** Check the publication date on [Maven Central](https://central.sonatype.com/) before adding any new coordinate. If a version was published less than 7 days ago, defer the addition until the cooldown has elapsed.
+
+**Treat plugin upgrades with the same scrutiny as runtime dependencies.** Maven plugins and Gradle build scripts execute arbitrary JVM code on the build host. A compromised plugin is strictly more dangerous than a compromised runtime library.
+
+**Never depend on `SNAPSHOT` versions** in production code. Snapshots are mutable and re-downloaded silently.
+
+## Maven Projects
+
+### Dependency Rules
+
+```xml
+<!-- Correct — exact version, managed centrally -->
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>3.2.1</version>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+```
+
+```xml
+<!-- Incorrect — do not use -->
+<version>[3.2,)</version>        <!-- range -->
+<version>LATEST</version>        <!-- dynamic -->
+<version>3.2-SNAPSHOT</version>  <!-- mutable -->
+```
+
+Every plugin must be pinned in `<build><pluginManagement>` with an explicit `<version>`.
+
+### Configuration to Verify
+
+**maven-enforcer-plugin** must be configured with these rules:
+
+- `banDynamicVersions` — fails on any range or `LATEST`/`RELEASE`.
+- `requirePluginVersions` (with `banLatest=true`, `banRelease=true`, `banSnapshots=true`).
+- `requireReleaseDeps` — fails on `SNAPSHOT` dependencies.
+- `dependencyConvergence` — fails when transitives disagree on a version.
+
+If `pom.xml` does not include the enforcer plugin, add it before making any other dependency changes.
+
+**Checksum policy** must be `fail` (not `warn`) — either in repository definitions or via `--strict-checksums` on every Maven invocation.
+
+**SCA tool** — at least one of OWASP Dependency-Check (`org.owasp:dependency-check-maven`), CycloneDX (`org.cyclonedx:cyclonedx-maven-plugin`), or Sonatype OSS Index must be configured and run in CI.
+
+### CI Commands (Maven)
+
+```bash
+mvn --batch-mode --strict-checksums --fail-fast verify
+mvn --batch-mode enforcer:enforce
+mvn --batch-mode org.owasp:dependency-check-maven:check
+```
+
+## Gradle Projects
+
+### Dependency Rules
+
+```kotlin
+// Correct — exact version, ideally via version catalog
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web:3.2.1")
+}
+```
+
+```kotlin
+// Incorrect — do not use
+implementation("group:name:1.+")
+implementation("group:name:latest.release")
+implementation("group:name:[1.2,2.0)")
+implementation("group:name:1.2.3-SNAPSHOT")
+```
+
+Prefer `gradle/libs.versions.toml` (version catalog) so every version is declared in one auditable place.
+
+### Configuration to Verify
+
+**Gradle Wrapper** must be committed (`gradle/wrapper/gradle-wrapper.properties`, `gradle/wrapper/gradle-wrapper.jar`, `gradlew`, `gradlew.bat`) and must include `distributionSha256Sum`. CI must invoke `./gradlew`, never a system-wide `gradle`.
+
+**Dynamic version rejection** must be configured at the root of the build:
+
+```kotlin
+allprojects {
+    configurations.all {
+        resolutionStrategy {
+            failOnNonReproducibleResolution()
+        }
+    }
+}
+```
+
+**Dependency Locking** must be enabled with strict mode:
+
+```kotlin
+allprojects {
+    dependencyLocking {
+        lockAllConfigurations()
+        lockMode.set(LockMode.STRICT)
+    }
+}
+```
+
+`gradle.lockfile` files must be committed (one per project module).
+
+**Dependency Verification** must be enabled — `gradle/verification-metadata.xml` must exist with `<verify-metadata>true</verify-metadata>` and (where feasible) `<verify-signatures>true</verify-signatures>`. SHA-256 entries for every artefact are mandatory; PGP entries are strongly preferred where publishers sign.
+
+**Repository control** must be in `settings.gradle.kts`:
+
+```kotlin
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+```
+
+`mavenLocal()` and `jcenter()` must not appear anywhere in the build. Internal coordinates must be served only by the internal repository via `exclusiveContent { filter { includeGroup("...") } }`.
+
+**SCA tool** — at least one of OWASP Dependency-Check (`org.owasp.dependencycheck`), CycloneDX (`org.cyclonedx.bom`), or Snyk must be configured and run in CI.
+
+### CI Commands (Gradle)
+
+```bash
+./gradlew --no-daemon --console=plain --stacktrace build
+./gradlew --no-daemon dependencyCheckAnalyze
+```
+
+**Never run `--write-locks` or `--write-verification-metadata` in CI.** Both are local-only operations performed by a human when intentionally updating dependencies.
+
+## CI Configuration — All JVM projects
+
+### Dependabot
+
+`.github/dependabot.yml` must include cooldowns for `maven` and/or `gradle` and `gradle-wrapper` ecosystems. If the file does not exist or lacks the cooldown blocks, add them:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "maven"      # or "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+
+  - package-ecosystem: "gradle-wrapper"   # Gradle projects only
+    directory: "/"
+    schedule:
+      interval: "weekly"
+```
+
+Security update PRs from Dependabot bypass the cooldown automatically and should be reviewed and merged promptly.
+
+### Harden-Runner
+
+Every GitHub Actions workflow that runs `mvn` or `./gradlew` must include `step-security/harden-runner` as its first step. Start in `audit` mode for new workflows, then tighten to `block` once the egress policy is stable:
+
+```yaml
+- uses: step-security/harden-runner@v2
+  with:
+    egress-policy: block
+    disable-sudo: true
+    allowed-endpoints: >
+      api.github.com:443
+      github.com:443
+      objects.githubusercontent.com:443
+      repo.maven.apache.org:443
+      repo1.maven.org:443
+      plugins.gradle.org:443
+      services.gradle.org:443
+      downloads.gradle.org:443
+```
+
+Add `nvd.nist.gov:443` and `services.nvd.nist.gov:443` if OWASP Dependency-Check downloads NVD data in CI. Add `dl.google.com:443` for Android/Kotlin projects pulling Google-hosted artefacts. Add private registry hostnames (Nexus, Artifactory, GitHub Packages) if used.
+
+## What Requires Human Review
+
+The following changes must not be made autonomously and require explicit human approval before proceeding:
+
+- Adding a new dependency or plugin not previously present in `pom.xml`, `build.gradle(.kts)`, or `libs.versions.toml`
+- Upgrading a major version
+- Changing exact pins to ranges or dynamic versions
+- Adding any `SNAPSHOT` dependency
+- Adding a new repository (Maven `<repository>` entry, Gradle `repositories { ... }` entry, mirror, or `<mirrorOf>` change)
+- Adding or modifying entries in `.mvn/extensions.xml` (these load before any POM is parsed — extremely sensitive)
+- Modifying `.github/dependabot.yml` cooldown values downward
+- Removing or modifying Harden-Runner from a workflow
+- Removing maven-enforcer-plugin rules or weakening them
+- Removing Gradle `dependencyLocking`, `failOnNonReproducibleResolution`, or dependency verification
+- Deleting `gradle.lockfile` or `gradle/verification-metadata.xml` (regenerate locally and commit, never delete)
+- Adding plugins that fetch or execute remote code at build time

--- a/docs/jvm.md
+++ b/docs/jvm.md
@@ -480,7 +480,7 @@ Security update PRs from Dependabot bypass the cooldown automatically and should
 Every GitHub Actions workflow that runs `mvn` or `./gradlew` must include `step-security/harden-runner` as its first step:
 
 ```yaml
-- uses: step-security/harden-runner@bb774aa972c2a89ff34781233d275075cbddf542 # v2
+- uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2
   with:
     egress-policy: block
     disable-sudo: true

--- a/docs/jvm.md
+++ b/docs/jvm.md
@@ -1,0 +1,508 @@
+<!--
+SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+SPDX-License-Identifier: MIT
+-->
+
+# JVM Ecosystem (Java, Kotlin, Scala)
+
+**Build tools covered:** Maven, Gradle (Groovy DSL and Kotlin DSL)
+
+Java and Kotlin share the same artefact ecosystem — Maven Central (`repo.maven.apache.org`) is the canonical registry, and the same `groupId:artifactId:version` coordinates are consumed by Maven, Gradle, sbt, Leiningen, and Mill. Hardening recommendations therefore apply equally regardless of language: a Kotlin/Android project using Gradle Kotlin DSL has the same supply-chain surface as a Java service using Maven.
+
+Two facts make the JVM ecosystem distinctive:
+
+1. **Build scripts execute arbitrary code.** Maven plugins and Gradle build scripts run JVM code on the build host. This is strictly worse than npm `postinstall` — a malicious plugin or build script has full access to the developer's machine and CI runner. Plugin and build-script versions must be pinned and reviewed with the same rigour as runtime dependencies.
+2. **Neither Maven nor Gradle has native minimum-release-age support.** Cooldown must be enforced via Dependabot (which supports both `maven` and `gradle` ecosystems) or Renovate.
+
+## Maven
+
+**Configuration files:** `pom.xml`, `~/.m2/settings.xml`, `.mvn/maven.config`, `.mvn/extensions.xml`
+
+### No native lockfile
+
+Maven has no built-in lockfile equivalent to `package-lock.json` or `Cargo.lock`. The `pom.xml` declares dependencies; transitive resolution happens fresh on each build unless every version (including transitives) is explicitly managed.
+
+Effective controls:
+
+- **Pin every direct dependency exactly** in `<dependencies>`.
+- **Pin every transitive dependency** in `<dependencyManagement>` — this forces Maven's resolver to a specific version regardless of what transitive ranges request.
+- **Pin every plugin** in `<build><pluginManagement>` and never omit `<version>` on a plugin declaration.
+- Use the **Maven Enforcer Plugin** rules to fail the build on any unpinned or ranged dependency.
+- Optionally adopt a third-party lockfile plugin such as [`io.github.chains-project:maven-lockfile`](https://github.com/chains-project/maven-lockfile) if reproducibility-by-hash is required.
+
+### Version Pinning
+
+Maven accepts both exact versions and Ivy-style version ranges. Ranges are rare in practice but must be banned explicitly because the resolver will silently pick the highest matching release on every build.
+
+```xml
+<!-- Correct — exact version -->
+<dependency>
+  <groupId>org.springframework.boot</groupId>
+  <artifactId>spring-boot-starter-web</artifactId>
+  <version>3.2.1</version>
+</dependency>
+```
+
+```xml
+<!-- Incorrect — do not use -->
+<version>[3.2,)</version>        <!-- open range -->
+<version>[3.2,4.0)</version>     <!-- bounded range -->
+<version>LATEST</version>        <!-- removed in Maven 3.5; still parsed by some plugins -->
+<version>RELEASE</version>       <!-- same -->
+<version>3.2-SNAPSHOT</version>  <!-- mutable; resolves to whatever the last upload was -->
+```
+
+| Syntax | Meaning |
+|--------|---------|
+| `3.2.1` | Soft requirement — exact unless overridden by `<dependencyManagement>` or transitive resolution |
+| `[3.2.1]` | Hard requirement — exact, build fails if anything else is forced |
+| `[3.2,4.0)` | Bounded range — resolver picks highest matching |
+| `[3.2,)` | Open range — resolver picks highest available |
+| `1.0-SNAPSHOT` | Mutable snapshot — re-downloaded on every build by default |
+
+Always use the bare exact form (`3.2.1`) combined with `<dependencyManagement>` for transitives. Hard requirements (`[3.2.1]`) can cause conflicts in multi-module builds where transitive consumers disagree.
+
+### Enforcing pinning with maven-enforcer-plugin
+
+The Enforcer plugin is the closest thing Maven has to lockfile enforcement at the manifest level:
+
+```xml
+<plugin>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>maven-enforcer-plugin</artifactId>
+  <version>3.5.0</version>
+  <executions>
+    <execution>
+      <id>enforce</id>
+      <goals><goal>enforce</goal></goals>
+      <configuration>
+        <rules>
+          <banDynamicVersions/>
+          <requirePluginVersions>
+            <banLatest>true</banLatest>
+            <banRelease>true</banRelease>
+            <banSnapshots>true</banSnapshots>
+          </requirePluginVersions>
+          <requireReleaseDeps>
+            <message>No SNAPSHOT dependencies allowed</message>
+          </requireReleaseDeps>
+          <dependencyConvergence/>
+        </rules>
+      </configuration>
+    </execution>
+  </executions>
+</plugin>
+```
+
+- `banDynamicVersions` — fails the build on any ranged or `LATEST`/`RELEASE` version.
+- `requirePluginVersions` — fails the build if any plugin is used without a pinned version.
+- `requireReleaseDeps` — fails the build on `SNAPSHOT` dependencies (useful for release branches).
+- `dependencyConvergence` — fails the build when multiple transitives disagree on a version, forcing an explicit `<dependencyManagement>` entry.
+
+### Checksum verification
+
+Maven verifies SHA-1 checksums against `.sha1` files alongside artefacts in the repository. By default it only **warns** on mismatch. Switch the policy to `fail`:
+
+```xml
+<!-- ~/.m2/settings.xml or repository definition in pom.xml -->
+<repository>
+  <id>central</id>
+  <url>https://repo.maven.apache.org/maven2</url>
+  <releases>
+    <enabled>true</enabled>
+    <checksumPolicy>fail</checksumPolicy>
+  </releases>
+  <snapshots>
+    <enabled>false</enabled>
+  </snapshots>
+</repository>
+```
+
+Or pass `--strict-checksums` (`-C`) on the command line. Note: Maven Central only publishes SHA-1 checksums by default; modern Maven Central artefacts also include `.sha256` and `.sha512` but plugin-level verification is patchy. For strong artefact verification, prefer Gradle's verification-metadata feature or use Sigstore-signed artefacts where available.
+
+### Snapshot dependencies
+
+`SNAPSHOT` versions are mutable — `1.0-SNAPSHOT` can be re-uploaded by the publisher at any time, and Maven re-downloads it (by default once per day) without changing the version string. **Never depend on a `SNAPSHOT` for production builds.** Use `<requireReleaseDeps>` in the Enforcer plugin to fail the build if any snapshot creeps in.
+
+If you publish snapshots internally, isolate them to a separate repository ID so they cannot mask a Central artefact.
+
+### Repository control
+
+Restrict Maven to known repositories. Avoid declaring arbitrary `<repository>` entries in `pom.xml`. Configure a mirror in `~/.m2/settings.xml` to route all resolution through a single, audited proxy (e.g. internal Nexus, Artifactory, or a Maven Central mirror):
+
+```xml
+<settings>
+  <mirrors>
+    <mirror>
+      <id>internal-mirror</id>
+      <mirrorOf>*</mirrorOf>
+      <url>https://nexus.example.com/repository/maven-public/</url>
+    </mirror>
+  </mirrors>
+</settings>
+```
+
+`<mirrorOf>*</mirrorOf>` forces every artefact request through the mirror regardless of what individual POMs declare. This is the strongest control against [dependency confusion / namespace squatting](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610) for internal coordinates.
+
+### Build script (plugin) execution
+
+Maven plugins run JVM code with the privileges of the build process. Treat plugin upgrades with the same scrutiny as runtime dependencies:
+
+- Pin every plugin version in `<pluginManagement>`.
+- Enforce with `requirePluginVersions`.
+- Avoid third-party plugins from low-reputation groups; prefer plugins published under `org.apache.maven.plugins`, `org.codehaus.mojo`, `org.jetbrains.kotlin`, or organisations you trust.
+- Plugins loaded via `.mvn/extensions.xml` are particularly sensitive — they run before any POM is parsed. Audit this file specifically.
+
+### Security scanning
+
+- **OWASP Dependency-Check** — `org.owasp:dependency-check-maven`. Scans against the NVD and GitHub Advisory Database.
+- **CycloneDX SBOM** — `org.cyclonedx:cyclonedx-maven-plugin`. Generates an SBOM that downstream scanners can consume.
+- **Sonatype OSS Index** — `org.sonatype.ossindex.maven:ossindex-maven-plugin`. Fails the build on known vulnerabilities.
+
+Pick one SCA tool and run it in CI on every build.
+
+```xml
+<plugin>
+  <groupId>org.owasp</groupId>
+  <artifactId>dependency-check-maven</artifactId>
+  <version>10.0.4</version>
+  <configuration>
+    <failBuildOnCVSS>7</failBuildOnCVSS>
+    <suppressionFile>dependency-check-suppressions.xml</suppressionFile>
+  </configuration>
+  <executions>
+    <execution>
+      <goals><goal>check</goal></goals>
+    </execution>
+  </executions>
+</plugin>
+```
+
+### CI Recommended Configuration
+
+```bash
+# Strict checksums, batch mode (no interactive prompts), fail fast
+mvn --batch-mode --strict-checksums --fail-fast \
+    -DskipTests=false \
+    verify
+
+# Run enforcer rules explicitly if not bound to a phase
+mvn --batch-mode enforcer:enforce
+
+# SCA
+mvn --batch-mode org.owasp:dependency-check-maven:check
+```
+
+Pass `-Dmaven.wagon.http.retryHandler.class=standard` and `-Dmaven.wagon.http.retryHandler.count=3` to make transient network failures retry rather than mask a registry-level issue.
+
+## Gradle
+
+**Configuration files:** `build.gradle` / `build.gradle.kts`, `settings.gradle` / `settings.gradle.kts`, `gradle.properties`, `gradle/wrapper/gradle-wrapper.properties`, `gradle.lockfile` (per configuration), `gradle/verification-metadata.xml`
+
+Gradle has stronger built-in supply-chain controls than Maven:
+
+- Native **dependency locking** produces a `gradle.lockfile` per configuration.
+- Native **dependency verification** records SHA-256 / SHA-512 hashes and (optionally) PGP signatures of every resolved artefact in `gradle/verification-metadata.xml` and fails the build on mismatch.
+- The **Gradle Wrapper** (`gradlew`) lets you pin the Gradle version itself, with a SHA-256 checksum.
+
+Use all three.
+
+### Gradle Wrapper version pinning
+
+`gradle/wrapper/gradle-wrapper.properties` pins the Gradle version. Always commit it and include the SHA-256 of the distribution:
+
+```properties
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionSha256Sum=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+```
+
+Regenerate after a Gradle upgrade with `./gradlew wrapper --gradle-version 8.10.2 --distribution-type bin`. CI must invoke `./gradlew`, never a system-wide `gradle` binary — the wrapper is the only thing pinning the Gradle version and its scripts.
+
+### Version Pinning
+
+Gradle accepts dynamic versions (`1.+`, `latest.release`, `[1.0,2.0)`). All of these must be banned:
+
+```kotlin
+// build.gradle.kts — correct
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web:3.2.1")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.17.2")
+}
+```
+
+```kotlin
+// build.gradle.kts — incorrect
+implementation("org.springframework.boot:spring-boot-starter-web:3.+")          // dynamic
+implementation("org.springframework.boot:spring-boot-starter-web:latest.release")
+implementation("org.springframework.boot:spring-boot-starter-web") {            // unspecified
+    version { strictly("[3.2,4.0)") }
+}
+```
+
+| Syntax | Meaning |
+|--------|---------|
+| `"group:name:1.2.3"` | Exact |
+| `"group:name:1.+"` | Dynamic — highest 1.x |
+| `"group:name:latest.release"` | Dynamic — highest non-snapshot |
+| `"group:name:[1.2,2.0)"` | Range |
+| `"group:name:1.2.3-SNAPSHOT"` | Mutable snapshot |
+
+Use [version catalogs](https://docs.gradle.org/current/userguide/platforms.html) (`gradle/libs.versions.toml`) so versions are declared once and referenced symbolically — this makes pinning auditable and makes Dependabot's PRs much easier to read.
+
+### Failing the build on dynamic versions
+
+Configure each resolution strategy to reject dynamic or changing versions:
+
+```kotlin
+// settings.gradle.kts or root build.gradle.kts
+allprojects {
+    configurations.all {
+        resolutionStrategy {
+            failOnDynamicVersions()
+            failOnChangingVersions()
+            failOnNonReproducibleResolution()
+        }
+    }
+}
+```
+
+`failOnNonReproducibleResolution()` combines the previous two and additionally rejects any resolution that depends on a mutable repository state.
+
+### Dependency Locking
+
+Enable lockfile generation for every configuration:
+
+```kotlin
+// settings.gradle.kts
+dependencyResolutionManagement {
+    // ...
+}
+
+// root build.gradle.kts
+allprojects {
+    dependencyLocking {
+        lockAllConfigurations()
+        lockMode.set(LockMode.STRICT)
+    }
+}
+```
+
+Generate or update the lockfile:
+
+```bash
+./gradlew dependencies --write-locks
+```
+
+This writes one `gradle.lockfile` per project containing every resolved coordinate. Commit these files. CI runs `./gradlew build` normally — `LockMode.STRICT` causes the build to fail if any resolution would diverge from the lockfile.
+
+Pass `--update-locks org.foo:*` to refresh a subset when intentionally updating.
+
+### Dependency Verification
+
+Generate the verification metadata for every artefact (jars, POMs, plugin marker artefacts):
+
+```bash
+./gradlew --write-verification-metadata sha256,pgp \
+          --export-keys \
+          help
+```
+
+This creates `gradle/verification-metadata.xml`:
+
+```xml
+<?xml version="1.1" encoding="UTF-8"?>
+<verification-metadata>
+  <configuration>
+    <verify-metadata>true</verify-metadata>
+    <verify-signatures>true</verify-signatures>
+  </configuration>
+  <trusted-keys>
+    <trusted-key id="..."/>
+  </trusted-keys>
+  <components>
+    <component group="org.springframework.boot" name="spring-boot-starter-web" version="3.2.1">
+      <artifact name="spring-boot-starter-web-3.2.1.jar">
+        <sha256 value="..." origin="Generated by Gradle"/>
+        <pgp value="..."/>
+      </artifact>
+    </component>
+    ...
+  </components>
+</verification-metadata>
+```
+
+Commit this file and the `gradle/verification-keyring.keys` it generates. Every subsequent build verifies SHA-256 and (where present) PGP signatures against this manifest and **fails** on any mismatch. This is the strongest artefact-integrity control available in any JVM build tool.
+
+Run with `--refresh-keys` after rotating signing keys. Run with `--write-verification-metadata sha256,pgp` again when adding or upgrading any dependency.
+
+### Repository control
+
+Restrict the repositories Gradle will use to a small, known set. In `settings.gradle.kts`:
+
+```kotlin
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+```
+
+`FAIL_ON_PROJECT_REPOS` prevents subprojects from quietly adding additional repositories. **Do not use `mavenLocal()`** — it allows artefacts from the developer's `~/.m2/repository` to silently substitute for Central. **Do not use `jcenter()`** — it has been read-only since 2022 and unmaintained since 2024.
+
+For internal artefacts, pair with a `repositories.exclusiveContent` block so that internal coordinates can only be served by your internal repository:
+
+```kotlin
+repositories {
+    exclusiveContent {
+        forRepository {
+            maven("https://nexus.example.com/repository/internal/")
+        }
+        filter {
+            includeGroup("com.example.internal")
+        }
+    }
+    mavenCentral()
+}
+```
+
+This is the canonical defence against dependency confusion attacks: `com.example.internal:*` can never be resolved from Maven Central, even if a malicious package with the same coordinates is published there.
+
+### Build script execution
+
+Gradle build scripts are Groovy or Kotlin code executed at evaluation time. A compromised plugin runs on every build with full filesystem and network access.
+
+- Pin every plugin version via the `plugins { id("...") version "x.y.z" }` block (or via version catalog).
+- Never use `plugins { id("...") version "+" }` or dynamic plugin versions.
+- Apply [`org.gradle.api.publish.PublishingExtension`](https://docs.gradle.org/current/userguide/dependency_verification.html) verification to plugins too — dependency verification covers plugin marker artefacts.
+- Run untrusted Gradle projects in a sandbox; `--no-daemon` is **not** a security boundary.
+
+### Security scanning
+
+- **OWASP Dependency-Check** — `org.owasp.dependencycheck` Gradle plugin.
+- **CycloneDX SBOM** — `org.cyclonedx.bom` Gradle plugin.
+- **Snyk / Sonatype OSS Index** — both publish official Gradle plugins.
+
+Pick one SCA tool and bind it to a CI task:
+
+```kotlin
+plugins {
+    id("org.owasp.dependencycheck") version "10.0.4"
+}
+
+dependencyCheck {
+    failBuildOnCVSS = 7.0f
+    suppressionFile = "dependency-check-suppressions.xml"
+}
+```
+
+### CI Recommended Configuration
+
+```bash
+# Use the wrapper — never a system gradle
+./gradlew \
+    --no-daemon \
+    --console=plain \
+    --stacktrace \
+    build
+
+# Dependency verification + lockfile enforcement happen automatically
+# during normal task execution (no separate flag required)
+
+# SCA
+./gradlew dependencyCheckAnalyze
+```
+
+`--no-daemon` in CI ensures every build starts from a clean JVM, avoiding any cross-build state.
+
+`--write-locks` and `--write-verification-metadata` must **never** run in CI. They are local-only operations to be performed by a human when intentionally updating dependencies.
+
+## sbt (Scala) — brief note
+
+If a Scala project is using sbt, the equivalent controls are:
+
+- Pin versions exactly in `build.sbt` (`libraryDependencies += "org" %% "name" % "1.2.3"`).
+- Enable [coursier](https://get-coursier.io/) and use `coursier resolve` to produce a lockfile-equivalent manifest, or use [`sbt-lock`](https://github.com/tkawachi/sbt-lock).
+- Pin the sbt version in `project/build.properties`.
+- Pin every sbt plugin in `project/plugins.sbt`.
+
+The Maven Central registry and `repo.maven.apache.org:443` egress are identical to Java/Kotlin projects.
+
+## Dependabot
+
+Dependabot supports both `maven` and `gradle` ecosystems. Both support `cooldown`:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+```
+
+The `gradle` ecosystem covers `build.gradle`, `build.gradle.kts`, and version catalogs (`gradle/libs.versions.toml`). It does **not** update the Gradle Wrapper version itself — for that, use the separate `gradle-wrapper` ecosystem:
+
+```yaml
+  - package-ecosystem: "gradle-wrapper"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+```
+
+Security update PRs from Dependabot bypass the cooldown automatically and should be reviewed and merged promptly.
+
+## Harden-Runner
+
+Every GitHub Actions workflow that runs `mvn` or `./gradlew` must include `step-security/harden-runner` as its first step:
+
+```yaml
+- uses: step-security/harden-runner@v2
+  with:
+    egress-policy: block
+    disable-sudo: true
+    allowed-endpoints: >
+      api.github.com:443
+      github.com:443
+      objects.githubusercontent.com:443
+      repo.maven.apache.org:443
+      repo1.maven.org:443
+      plugins.gradle.org:443
+      services.gradle.org:443
+      downloads.gradle.org:443
+      jcenter.bintray.com:443
+```
+
+Endpoint notes:
+
+- `repo.maven.apache.org` and `repo1.maven.org` are both Maven Central — different DNS entries used by different clients and CDNs.
+- `plugins.gradle.org` serves the Gradle Plugin Portal.
+- `services.gradle.org` and `downloads.gradle.org` serve the Gradle distribution zip referenced by `gradle-wrapper.properties`.
+- For private registries (Nexus, Artifactory, GitHub Packages Maven), add the hostname.
+- For Kotlin projects, also include `dl.google.com:443` if pulling Android-related artefacts.
+- For OWASP Dependency-Check NVD downloads, add `nvd.nist.gov:443` and `services.nvd.nist.gov:443`.
+
+Start in `audit` mode for new workflows and switch to `block` after reviewing audit logs to build a confirmed allowlist.

--- a/docs/jvm.md
+++ b/docs/jvm.md
@@ -480,7 +480,7 @@ Security update PRs from Dependabot bypass the cooldown automatically and should
 Every GitHub Actions workflow that runs `mvn` or `./gradlew` must include `step-security/harden-runner` as its first step:
 
 ```yaml
-- uses: step-security/harden-runner@v2
+- uses: step-security/harden-runner@bb774aa972c2a89ff34781233d275075cbddf542 # v2
   with:
     egress-policy: block
     disable-sudo: true

--- a/skills/harden-packages/SKILL.md
+++ b/skills/harden-packages/SKILL.md
@@ -9,7 +9,8 @@ description: >
   review CI/CD pipeline security. Also trigger when the user says things like "harden
   my repo", "check my dependencies", "is my package config secure?", "set up supply
   chain security", "add Dependabot", or "are my packages safe?". Works across Node.js
-  (npm/pnpm/yarn/bun), Python (pip/uv), Go, Rust/Cargo, PHP/Composer, Ruby/Bundler, and Terraform/OpenTofu repos
+  (npm/pnpm/yarn/bun), Python (pip/uv), Go, Rust/Cargo, PHP/Composer, Ruby/Bundler,
+  JVM (Maven, Gradle — Java and Kotlin), and Terraform/OpenTofu repos
 ---
 
 <!--
@@ -46,7 +47,7 @@ section below.
 
 Read the JSON output. The top-level keys are:
 
-- `ecosystems_detected` — list of ecosystems found (nodejs, python, go, rust, php, ruby, terraform)
+- `ecosystems_detected` — list of ecosystems found (nodejs, python, go, rust, php, ruby, terraform, maven, gradle)
 - One key per ecosystem (e.g. `nodejs`, `python`) with nested findings
 - `dependabot` — per-ecosystem Dependabot configuration status
 - `harden_runner` — per-workflow Harden-Runner status
@@ -64,6 +65,18 @@ Each check has a `status` field: `"pass"`, `"warn"`, `"fail"`, or `"missing"`.
 - `harden_runner.workflows.<name>.egress_policy: audit` — runner is present but in audit mode, not block. Flag as ⚠️.
 - `harden_runner.workflows.<name>.harden_runner_present: false` — missing entirely. Flag as ❌.
 - `terraform.known_bug` — always flag: Dependabot cooldown for terraform providers has a known bug; exact pinning is the primary control.
+- `maven.exact_pins.loose` — pom.xml `<version>` entries that are ranges (`[1.2,2.0)`), `LATEST`, `RELEASE`, or `SNAPSHOT`. Every entry is a real finding. Property placeholders (`${...}`) are not flagged.
+- `maven.enforcer_plugin.status: fail` — `maven-enforcer-plugin` is missing or has fewer than two of the canonical hardening rules (`banDynamicVersions`, `requirePluginVersions`, `requireReleaseDeps`, `dependencyConvergence`). Maven has no native lockfile; the enforcer plugin is the substitute.
+- `maven.strict_checksums.status: fail` — neither `<checksumPolicy>fail</checksumPolicy>` nor `--strict-checksums` / `-C` on the CI invocation. Maven defaults to *warn*, not *fail*, on checksum mismatch.
+- `maven.sca_scanner.status: fail` — no OWASP Dependency-Check, CycloneDX, or OSS Index plugin configured.
+- `gradle.exact_pins.loose` — `build.gradle(.kts)` dependency strings with `+`, `latest.release`, ranges, or `SNAPSHOT`.
+- `gradle.dependency_locking.status: fail` — `dependencyLocking { lockAllConfigurations() }` missing, not in `LockMode.STRICT`, or no `gradle.lockfile` committed.
+- `gradle.dependency_verification.status: fail` — `gradle/verification-metadata.xml` missing or `verify-metadata` not set to true. This is the strongest artefact-integrity control on the JVM; recommend it whenever it's absent.
+- `gradle.wrapper.status: fail` — `gradle-wrapper.properties` missing `distributionSha256Sum=` line. The Gradle Wrapper download is otherwise unverified.
+- `gradle.repository_control` — flag any of: `FAIL_ON_PROJECT_REPOS` not set, `mavenLocal()` present (allows developer-local artefacts to substitute for Central), `jcenter()` present (unmaintained since 2024).
+- `gradle.reject_dynamic.status: fail` — neither `failOnNonReproducibleResolution()` nor `failOnDynamicVersions()` configured.
+- `gradle.ci.writes_locks_in_ci: true` — CI is running `--write-locks` or `--write-verification-metadata`. These are local-only operations; running them in CI defeats the controls. Always flag.
+- `dependabot.ecosystems.gradle.gradle_wrapper_ecosystem: missing` — sub-finding: the Gradle Wrapper has its own Dependabot ecosystem (`gradle-wrapper`) separate from `gradle`, and is missing.
 
 ## Step 3: Report findings
 
@@ -120,8 +133,10 @@ If the user agrees (fully or partially), apply the fixes in this order — lower
 4. `composer.json` — add `roave/security-advisories` dev dependency; tighten `^`/`~` pins to exact (flag for human review)
 5. Ruby CI — add `BUNDLE_FROZEN=true` and `bundle audit check` to CI workflow
 6. Terraform `*.tf` — tighten `~>` / `>=` constraints to `=` exact pins (**do not apply autonomously** — present proposed changes and require explicit human approval; changing constraints can cause `terraform init` to fail)
-7. `.github/dependabot.yml` — add missing ecosystem entries with cooldown blocks
-8. `.github/workflows/*.yml` — add or update harden-runner steps
+7. Maven `pom.xml` — add `maven-enforcer-plugin` with `banDynamicVersions` / `requirePluginVersions` / `requireReleaseDeps` / `dependencyConvergence`; set `<checksumPolicy>fail</checksumPolicy>` (**do not autonomously change `<version>` pins** — flag for human review, since tightening a transitive can break downstream consumers)
+8. Gradle `build.gradle(.kts)` / `settings.gradle(.kts)` — add `dependencyLocking { lockAllConfigurations(); lockMode.set(LockMode.STRICT) }`, `failOnNonReproducibleResolution()`, and `RepositoriesMode.FAIL_ON_PROJECT_REPOS`; remove `mavenLocal()` and `jcenter()` (**flag — repository changes can break local development**). Generating `gradle.lockfile` and `gradle/verification-metadata.xml` requires running `./gradlew --write-locks` and `./gradlew --write-verification-metadata sha256,pgp help` locally — do not run these in CI, and do not run them autonomously; instruct the user to run them and commit the result.
+9. `.github/dependabot.yml` — add missing ecosystem entries with cooldown blocks
+10. `.github/workflows/*.yml` — add or update harden-runner steps
 
 For each file you modify, show a clear before/after diff and explain what changed and why.
 
@@ -250,6 +265,136 @@ bundle exec bundle-audit check --update
       index.rubygems.org:443
 ```
 
+**Maven enforcer plugin (add to `<build><plugins>` in pom.xml):**
+
+```xml
+<plugin>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>maven-enforcer-plugin</artifactId>
+  <version>3.5.0</version>
+  <executions>
+    <execution>
+      <id>enforce</id>
+      <goals><goal>enforce</goal></goals>
+      <configuration>
+        <rules>
+          <banDynamicVersions/>
+          <requirePluginVersions>
+            <banLatest>true</banLatest>
+            <banRelease>true</banRelease>
+            <banSnapshots>true</banSnapshots>
+          </requirePluginVersions>
+          <requireReleaseDeps/>
+          <dependencyConvergence/>
+        </rules>
+      </configuration>
+    </execution>
+  </executions>
+</plugin>
+```
+
+**Maven strict checksums (settings.xml repository entry):**
+
+```xml
+<releases>
+  <enabled>true</enabled>
+  <checksumPolicy>fail</checksumPolicy>
+</releases>
+```
+
+**Maven CI invocation:**
+
+```bash
+mvn --batch-mode --strict-checksums --fail-fast verify
+mvn --batch-mode org.owasp:dependency-check-maven:check
+```
+
+**Dependabot maven ecosystem entry:**
+
+```yaml
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+```
+
+**Gradle hardening block (root build.gradle.kts):**
+
+```kotlin
+allprojects {
+    configurations.all {
+        resolutionStrategy {
+            failOnNonReproducibleResolution()
+        }
+    }
+    dependencyLocking {
+        lockAllConfigurations()
+        lockMode.set(LockMode.STRICT)
+    }
+}
+```
+
+**Gradle repository control (settings.gradle.kts):**
+
+```kotlin
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+```
+
+**Gradle generate lockfile and verification metadata (run locally, commit the result — never in CI):**
+
+```bash
+./gradlew dependencies --write-locks
+./gradlew --write-verification-metadata sha256,pgp --export-keys help
+```
+
+**Gradle CI invocation:**
+
+```bash
+./gradlew --no-daemon --console=plain --stacktrace build
+./gradlew --no-daemon dependencyCheckAnalyze
+```
+
+**Dependabot gradle + gradle-wrapper ecosystem entries:**
+
+```yaml
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+  - package-ecosystem: "gradle-wrapper"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+```
+
+**Harden-Runner endpoints for Maven and Gradle:**
+
+```yaml
+      repo.maven.apache.org:443
+      repo1.maven.org:443
+      plugins.gradle.org:443
+      services.gradle.org:443
+      downloads.gradle.org:443
+```
+
+Add `nvd.nist.gov:443 services.nvd.nist.gov:443` if OWASP Dependency-Check runs in CI. Add `dl.google.com:443` for Android/Kotlin projects. Add private registry hostnames (Nexus, Artifactory, GitHub Packages) if used.
+
 **Terraform required_providers exact pinning:**
 
 ```hcl
@@ -315,6 +460,7 @@ Append the ecosystem-specific endpoints:
 - Rust: `crates.io:443 index.crates.io:443 static.crates.io:443`
 - PHP: `packagist.org:443 repo.packagist.org:443`
 - Ruby: `rubygems.org:443 api.rubygems.org:443 index.rubygems.org:443` (add `raw.githubusercontent.com:443` if `bundle audit update` runs in CI)
+- Maven / Gradle: `repo.maven.apache.org:443 repo1.maven.org:443 plugins.gradle.org:443 services.gradle.org:443 downloads.gradle.org:443` (add `nvd.nist.gov:443 services.nvd.nist.gov:443` if OWASP Dependency-Check runs; `dl.google.com:443` for Android/Kotlin)
 - Terraform: `registry.terraform.io:443 releases.hashicorp.com:443 checkpoint-api.hashicorp.com:443`
 - OpenTofu: `registry.opentofu.org:443` (provider binary CDN endpoints vary by provider — discover via `audit` mode first)
 
@@ -388,6 +534,36 @@ Use this section only if `audit.py` cannot be run. It replicates what the script
 - Is `BUNDLE_FROZEN=true` set in CI?
 - Does CI run `bundle audit check`?
 - Is a `ruby` directive in `Gemfile` or a `.ruby-version` file committed?
+
+### JVM (Maven / Gradle — Java / Kotlin)
+
+**Maven (`pom.xml` present):**
+
+- Do all `<version>` entries use exact, immutable values? Flag any range (`[1.2,2.0)`, `(1.2,)`), `LATEST`, `RELEASE`, or `SNAPSHOT`.
+- Is every plugin pinned in `<build><pluginManagement>` with an explicit `<version>`?
+- Is `maven-enforcer-plugin` configured with at least two of: `banDynamicVersions`, `requirePluginVersions`, `requireReleaseDeps`, `dependencyConvergence`?
+- Is the checksum policy `fail` — either via `<checksumPolicy>fail</checksumPolicy>` in a repository definition or via `--strict-checksums` / `-C` on every CI Maven invocation?
+- Is at least one SCA scanner (`dependency-check-maven`, `cyclonedx-maven-plugin`, or `ossindex-maven-plugin`) wired into the build?
+- Does CI pass `--batch-mode` and `--fail-fast`?
+- Is `.mvn/extensions.xml` reviewed? Extensions load before any POM is parsed and run JVM code on the build host.
+
+**Gradle (`build.gradle` or `build.gradle.kts` present):**
+
+- Are all dependency coordinates exact? Flag any `+`, `latest.release`, range (`[1.0,2.0)`), or `SNAPSHOT`.
+- Is `dependencyLocking { lockAllConfigurations(); lockMode.set(LockMode.STRICT) }` configured at the root and is `gradle.lockfile` committed for every project module?
+- Is `gradle/verification-metadata.xml` committed, with `<verify-metadata>true</verify-metadata>` and ideally `<verify-signatures>true</verify-signatures>`?
+- Does `gradle/wrapper/gradle-wrapper.properties` include a `distributionSha256Sum=` line?
+- In `settings.gradle(.kts)`, is `repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)` set?
+- Is `mavenLocal()` or `jcenter()` referenced anywhere? Both are red flags.
+- Is `failOnNonReproducibleResolution()` (or `failOnDynamicVersions()` + `failOnChangingVersions()`) configured on every configuration?
+- Does CI invoke `./gradlew` (not a system `gradle`) and pass `--no-daemon`?
+- Does CI ever run `--write-locks` or `--write-verification-metadata`? If so, that defeats the controls and must be removed.
+- Is at least one SCA plugin (`org.owasp.dependencycheck`, `org.cyclonedx.bom`, or Snyk) configured?
+
+**Dependabot ecosystems for JVM projects:**
+
+- Maven: `package-ecosystem: "maven"` with cooldown.
+- Gradle: `package-ecosystem: "gradle"` with cooldown, **plus** `package-ecosystem: "gradle-wrapper"` (a separate ecosystem that updates the Wrapper version itself).
 
 ### Terraform / OpenTofu
 

--- a/skills/harden-packages/SKILL.md
+++ b/skills/harden-packages/SKILL.md
@@ -442,7 +442,7 @@ terraform providers lock \
 **Harden-Runner step (start in audit mode; switch to block after confirming allowlist):**
 
 ```yaml
-- uses: step-security/harden-runner@v2
+- uses: step-security/harden-runner@bb774aa972c2a89ff34781233d275075cbddf542 # v2
   with:
     egress-policy: audit
     disable-sudo: true
@@ -580,6 +580,6 @@ Use this section only if `audit.py` cannot be run. It replicates what the script
 
 ### Harden-Runner
 
-- Is `step-security/harden-runner@v2` the first step in every job that installs dependencies?
+- Is `step-security/harden-runner` (SHA-pinned, e.g. `@bb774aa972c2a89ff34781233d275075cbddf542 # v2`) the first step in every job that installs dependencies? Flag any `@v2` / `@v3` / `@main` references — actions must be SHA-pinned to a 40-char commit, with a `# vX.Y.Z` trailing comment.
 - Is `egress-policy` set to `block` (not `audit`)? Is `disable-sudo: true` set?
 - Are job-level `uses:` entries (reusable workflows) SHA-pinned? These are mutable refs just like step-level `uses:` but **cannot receive harden-runner steps** — the entire job is delegated to the reusable workflow. Flag unpinned reusable workflow refs separately from the harden-runner audit.

--- a/skills/harden-packages/SKILL.md
+++ b/skills/harden-packages/SKILL.md
@@ -442,7 +442,7 @@ terraform providers lock \
 **Harden-Runner step (start in audit mode; switch to block after confirming allowlist):**
 
 ```yaml
-- uses: step-security/harden-runner@bb774aa972c2a89ff34781233d275075cbddf542 # v2
+- uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2
   with:
     egress-policy: audit
     disable-sudo: true
@@ -580,6 +580,6 @@ Use this section only if `audit.py` cannot be run. It replicates what the script
 
 ### Harden-Runner
 
-- Is `step-security/harden-runner` (SHA-pinned, e.g. `@bb774aa972c2a89ff34781233d275075cbddf542 # v2`) the first step in every job that installs dependencies? Flag any `@v2` / `@v3` / `@main` references — actions must be SHA-pinned to a 40-char commit, with a `# vX.Y.Z` trailing comment.
+- Is `step-security/harden-runner` (SHA-pinned, e.g. `@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2`) the first step in every job that installs dependencies? Flag any `@v2` / `@v3` / `@main` references — actions must be SHA-pinned to a 40-char commit, with a `# vX.Y.Z` trailing comment.
 - Is `egress-policy` set to `block` (not `audit`)? Is `disable-sudo: true` set?
 - Are job-level `uses:` entries (reusable workflows) SHA-pinned? These are mutable refs just like step-level `uses:` but **cannot receive harden-runner steps** — the entire job is delegated to the reusable workflow. Flag unpinned reusable workflow refs separately from the harden-runner audit.

--- a/skills/harden-packages/audit.py
+++ b/skills/harden-packages/audit.py
@@ -108,6 +108,12 @@ def detect_ecosystems(root):
                 detected.append("terraform")
                 break
 
+    if (r / "pom.xml").exists():
+        detected.append("maven")
+    if (r / "build.gradle").exists() or (r / "build.gradle.kts").exists() \
+            or (r / "settings.gradle").exists() or (r / "settings.gradle.kts").exists():
+        detected.append("gradle")
+
     return detected
 
 
@@ -585,6 +591,217 @@ def audit_terraform(root):
 
 
 # ---------------------------------------------------------------------------
+# JVM audits — Maven and Gradle are detected and audited separately because
+# they have distinct Dependabot ecosystem keys and entirely different finding
+# shapes. The user-facing skill documentation refers to both under the "JVM"
+# umbrella.
+# ---------------------------------------------------------------------------
+
+
+def audit_maven(root):
+    r = Path(root)
+    findings = {}
+
+    pom = read(r / "pom.xml")
+    findings["pom_xml"] = {"present": bool(pom)}
+
+    # Detect loose / mutable version constraints in <version> elements
+    loose = []
+    for m in re.finditer(r"<version>([^<]+)</version>", pom):
+        ver = m.group(1).strip()
+        # Skip property placeholders (${...}) — they're resolved elsewhere
+        if ver.startswith("${"):
+            continue
+        bad = False
+        # Ranges
+        if ver.startswith("[") or ver.startswith("("):
+            bad = True
+        # Dynamic keywords
+        if ver in ("LATEST", "RELEASE"):
+            bad = True
+        # SNAPSHOTs (mutable)
+        if ver.endswith("-SNAPSHOT") or "SNAPSHOT" in ver:
+            bad = True
+        if bad:
+            loose.append(ver)
+    findings["exact_pins"] = {
+        "status": status(len(loose) == 0),
+        "loose": loose[:20],
+        "loose_count": len(loose),
+    }
+
+    # maven-enforcer-plugin with the canonical hardening rules
+    has_enforcer = "maven-enforcer-plugin" in pom
+    ban_dynamic = bool(re.search(r"<banDynamicVersions\s*/?>", pom))
+    require_plugin_versions = bool(re.search(r"<requirePluginVersions\b", pom))
+    require_release_deps = bool(re.search(r"<requireReleaseDeps\b", pom))
+    dependency_convergence = bool(re.search(r"<dependencyConvergence\s*/?>", pom))
+    rules_present = sum(
+        [ban_dynamic, require_plugin_versions, require_release_deps, dependency_convergence]
+    )
+    findings["enforcer_plugin"] = {
+        "present": has_enforcer,
+        "ban_dynamic_versions": ban_dynamic,
+        "require_plugin_versions": require_plugin_versions,
+        "require_release_deps": require_release_deps,
+        "dependency_convergence": dependency_convergence,
+        "status": status(has_enforcer and rules_present >= 2),
+    }
+
+    # Checksum policy — look for <checksumPolicy>fail</checksumPolicy> in pom or
+    # for --strict-checksums / -C in CI workflows.
+    wfs = workflow_files(root)
+    all_wf = "\n".join(wfs.values())
+    strict_in_pom = "fail" in re.findall(
+        r"<checksumPolicy>([^<]+)</checksumPolicy>", pom
+    )
+    strict_in_ci = grep(all_wf, r"--strict-checksums|\s-C\b")
+    findings["strict_checksums"] = {
+        "in_pom": strict_in_pom,
+        "in_ci": strict_in_ci,
+        "status": status(strict_in_pom or strict_in_ci),
+    }
+
+    # SCA scanner — at least one of OWASP Dependency-Check, CycloneDX, OSS Index
+    has_dependency_check = "dependency-check-maven" in pom
+    has_cyclonedx = "cyclonedx-maven-plugin" in pom
+    has_ossindex = "ossindex-maven-plugin" in pom
+    findings["sca_scanner"] = {
+        "owasp_dependency_check": has_dependency_check,
+        "cyclonedx": has_cyclonedx,
+        "ossindex": has_ossindex,
+        "status": status(has_dependency_check or has_cyclonedx or has_ossindex),
+    }
+
+    # CI invokes maven with --batch-mode (deterministic, fail-fast)
+    has_batch_mode = grep(all_wf, r"--batch-mode|\s-B\b")
+    findings["ci"] = {
+        "batch_mode": has_batch_mode,
+        "strict_checksums": strict_in_ci,
+        "status": status(has_batch_mode and (strict_in_pom or strict_in_ci)),
+    }
+
+    return findings
+
+
+def audit_gradle(root):
+    r = Path(root)
+    findings = {}
+
+    # Gather all build script content
+    build_files = []
+    for name in ("build.gradle", "build.gradle.kts", "settings.gradle", "settings.gradle.kts"):
+        if (r / name).exists():
+            build_files.append(r / name)
+    build_files += [p for p in r.rglob("build.gradle") if p not in build_files]
+    build_files += [p for p in r.rglob("build.gradle.kts") if p not in build_files]
+    build_content = "\n".join(read(p) for p in build_files)
+
+    findings["build_files"] = [str(p.relative_to(r)) for p in build_files][:20]
+
+    # Detect dynamic versions in dependency strings
+    loose = []
+    # "group:name:1.+" / "group:name:latest.release" / "group:name:[1.0,2.0)"
+    for m in re.finditer(r'["\']([\w.\-]+):([\w.\-]+):([^"\']+)["\']', build_content):
+        ver = m.group(3)
+        if (
+            "+" in ver
+            or "latest" in ver.lower()
+            or ver.startswith("[")
+            or ver.startswith("(")
+            or "SNAPSHOT" in ver
+        ):
+            loose.append(f"{m.group(1)}:{m.group(2)}:{ver}")
+    findings["exact_pins"] = {
+        "status": status(len(loose) == 0),
+        "loose": loose[:20],
+        "loose_count": len(loose),
+    }
+
+    # Dependency locking
+    has_locking_block = grep(build_content, r"dependencyLocking\s*\{")
+    lock_all = grep(build_content, r"lockAllConfigurations\s*\(")
+    strict_mode = grep(build_content, r"LockMode\.STRICT|lockMode\.set\(\s*LockMode\.STRICT")
+    lockfiles = list(r.rglob("gradle.lockfile"))
+    findings["dependency_locking"] = {
+        "configured": has_locking_block,
+        "lock_all_configurations": lock_all,
+        "strict_mode": strict_mode,
+        "lockfile_count": len(lockfiles),
+        "status": status(has_locking_block and lock_all and bool(lockfiles)),
+    }
+
+    # Dependency verification (gradle/verification-metadata.xml)
+    vm = r / "gradle" / "verification-metadata.xml"
+    vm_content = read(vm)
+    verify_metadata = "verify-metadata>true" in vm_content
+    verify_signatures = "verify-signatures>true" in vm_content
+    findings["dependency_verification"] = {
+        "file_present": vm.exists(),
+        "verify_metadata": verify_metadata,
+        "verify_signatures": verify_signatures,
+        "status": status(vm.exists() and verify_metadata),
+    }
+
+    # Gradle Wrapper SHA pinning
+    wrapper_props = read(r / "gradle" / "wrapper" / "gradle-wrapper.properties")
+    has_sha = bool(re.search(r"^distributionSha256Sum\s*=", wrapper_props, re.MULTILINE))
+    findings["wrapper"] = {
+        "properties_present": bool(wrapper_props),
+        "distribution_sha256": has_sha,
+        "status": status(bool(wrapper_props) and has_sha),
+    }
+
+    # Repository control
+    fail_on_project_repos = grep(build_content, r"FAIL_ON_PROJECT_REPOS")
+    uses_maven_local = grep(build_content, r"mavenLocal\s*\(")
+    uses_jcenter = grep(build_content, r"jcenter\s*\(")
+    findings["repository_control"] = {
+        "fail_on_project_repos": fail_on_project_repos,
+        "uses_mavenLocal": uses_maven_local,
+        "uses_jcenter": uses_jcenter,
+        "status": status(
+            fail_on_project_repos and not uses_maven_local and not uses_jcenter
+        ),
+    }
+
+    # Reproducible resolution (rejects dynamic/changing/mutable)
+    rejects_dynamic = grep(build_content, r"failOnNonReproducibleResolution|failOnDynamicVersions")
+    findings["reject_dynamic"] = {
+        "status": status(rejects_dynamic),
+        "configured": rejects_dynamic,
+    }
+
+    # SCA plugin
+    has_dependency_check = "org.owasp.dependencycheck" in build_content
+    has_cyclonedx = "org.cyclonedx.bom" in build_content
+    has_snyk = "io.snyk.gradle.plugin" in build_content
+    findings["sca_scanner"] = {
+        "owasp_dependency_check": has_dependency_check,
+        "cyclonedx": has_cyclonedx,
+        "snyk": has_snyk,
+        "status": status(has_dependency_check or has_cyclonedx or has_snyk),
+    }
+
+    # CI uses ./gradlew (not system gradle) and --no-daemon
+    wfs = workflow_files(root)
+    all_wf = "\n".join(wfs.values())
+    uses_wrapper = grep(all_wf, r"\./gradlew\b")
+    uses_no_daemon = grep(all_wf, r"--no-daemon")
+    # Flag if --write-locks or --write-verification-metadata appears in CI (must
+    # be local-only)
+    writes_locks_in_ci = grep(all_wf, r"--write-locks|--write-verification-metadata")
+    findings["ci"] = {
+        "uses_wrapper": uses_wrapper,
+        "no_daemon": uses_no_daemon,
+        "writes_locks_in_ci": writes_locks_in_ci,
+        "status": status(uses_wrapper and not writes_locks_in_ci),
+    }
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
 # Dependabot audit
 # ---------------------------------------------------------------------------
 
@@ -596,6 +813,8 @@ ECOSYSTEM_KEYS = {
     "php": "composer",
     "ruby": "bundler",
     "terraform": "terraform",
+    "maven": "maven",
+    "gradle": "gradle",
 }
 
 
@@ -640,6 +859,15 @@ def audit_dependabot(root, detected_ecosystems):
             if eco == "terraform":
                 eco_findings[eco]["known_bug"] = (
                     "Dependabot cooldown may not be respected for terraform providers (issue #13715)"
+                )
+            if eco == "gradle":
+                # Gradle Wrapper version is a separate Dependabot ecosystem;
+                # surface it as a sub-finding so the LLM can flag if missing.
+                wrapper_present = grep(
+                    content, r'package-ecosystem:\s*["\']?gradle-wrapper["\']?'
+                )
+                eco_findings[eco]["gradle_wrapper_ecosystem"] = (
+                    "pass" if wrapper_present else "missing"
                 )
         else:
             eco_findings[eco] = {"status": "missing", "ecosystem_key": key}
@@ -727,6 +955,8 @@ def main():
         "php": audit_php,
         "ruby": audit_ruby,
         "terraform": audit_terraform,
+        "maven": audit_maven,
+        "gradle": audit_gradle,
     }
 
     for eco in detected:

--- a/skills/harden-packages/audit.py
+++ b/skills/harden-packages/audit.py
@@ -110,8 +110,12 @@ def detect_ecosystems(root):
 
     if (r / "pom.xml").exists():
         detected.append("maven")
-    if (r / "build.gradle").exists() or (r / "build.gradle.kts").exists() \
-            or (r / "settings.gradle").exists() or (r / "settings.gradle.kts").exists():
+    if (
+        (r / "build.gradle").exists()
+        or (r / "build.gradle.kts").exists()
+        or (r / "settings.gradle").exists()
+        or (r / "settings.gradle.kts").exists()
+    ):
         detected.append("gradle")
 
     return detected
@@ -636,9 +640,7 @@ def audit_maven(root):
     require_plugin_versions = bool(re.search(r"<requirePluginVersions\b", pom))
     require_release_deps = bool(re.search(r"<requireReleaseDeps\b", pom))
     dependency_convergence = bool(re.search(r"<dependencyConvergence\s*/?>", pom))
-    rules_present = sum(
-        [ban_dynamic, require_plugin_versions, require_release_deps, dependency_convergence]
-    )
+    rules_present = sum([ban_dynamic, require_plugin_versions, require_release_deps, dependency_convergence])
     findings["enforcer_plugin"] = {
         "present": has_enforcer,
         "ban_dynamic_versions": ban_dynamic,
@@ -652,9 +654,7 @@ def audit_maven(root):
     # for --strict-checksums / -C in CI workflows.
     wfs = workflow_files(root)
     all_wf = "\n".join(wfs.values())
-    strict_in_pom = "fail" in re.findall(
-        r"<checksumPolicy>([^<]+)</checksumPolicy>", pom
-    )
+    strict_in_pom = "fail" in re.findall(r"<checksumPolicy>([^<]+)</checksumPolicy>", pom)
     strict_in_ci = grep(all_wf, r"--strict-checksums|\s-C\b")
     findings["strict_checksums"] = {
         "in_pom": strict_in_pom,
@@ -704,13 +704,7 @@ def audit_gradle(root):
     # "group:name:1.+" / "group:name:latest.release" / "group:name:[1.0,2.0)"
     for m in re.finditer(r'["\']([\w.\-]+):([\w.\-]+):([^"\']+)["\']', build_content):
         ver = m.group(3)
-        if (
-            "+" in ver
-            or "latest" in ver.lower()
-            or ver.startswith("[")
-            or ver.startswith("(")
-            or "SNAPSHOT" in ver
-        ):
+        if "+" in ver or "latest" in ver.lower() or ver.startswith("[") or ver.startswith("(") or "SNAPSHOT" in ver:
             loose.append(f"{m.group(1)}:{m.group(2)}:{ver}")
     findings["exact_pins"] = {
         "status": status(len(loose) == 0),
@@ -760,9 +754,7 @@ def audit_gradle(root):
         "fail_on_project_repos": fail_on_project_repos,
         "uses_mavenLocal": uses_maven_local,
         "uses_jcenter": uses_jcenter,
-        "status": status(
-            fail_on_project_repos and not uses_maven_local and not uses_jcenter
-        ),
+        "status": status(fail_on_project_repos and not uses_maven_local and not uses_jcenter),
     }
 
     # Reproducible resolution (rejects dynamic/changing/mutable)
@@ -863,12 +855,8 @@ def audit_dependabot(root, detected_ecosystems):
             if eco == "gradle":
                 # Gradle Wrapper version is a separate Dependabot ecosystem;
                 # surface it as a sub-finding so the LLM can flag if missing.
-                wrapper_present = grep(
-                    content, r'package-ecosystem:\s*["\']?gradle-wrapper["\']?'
-                )
-                eco_findings[eco]["gradle_wrapper_ecosystem"] = (
-                    "pass" if wrapper_present else "missing"
-                )
+                wrapper_present = grep(content, r'package-ecosystem:\s*["\']?gradle-wrapper["\']?')
+                eco_findings[eco]["gradle_wrapper_ecosystem"] = "pass" if wrapper_present else "missing"
         else:
             eco_findings[eco] = {"status": "missing", "ecosystem_key": key}
 

--- a/tests/test_audit_jvm.py
+++ b/tests/test_audit_jvm.py
@@ -1,0 +1,448 @@
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+#
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for audit_maven() and audit_gradle()."""
+
+import audit
+from conftest import make_workflow, write_file
+
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+def test_detect_maven(tmp_path):
+    (tmp_path / "pom.xml").write_text("<project/>")
+    assert "maven" in audit.detect_ecosystems(str(tmp_path))
+
+
+def test_detect_gradle_groovy(tmp_path):
+    (tmp_path / "build.gradle").write_text("")
+    assert "gradle" in audit.detect_ecosystems(str(tmp_path))
+
+
+def test_detect_gradle_kotlin(tmp_path):
+    (tmp_path / "build.gradle.kts").write_text("")
+    assert "gradle" in audit.detect_ecosystems(str(tmp_path))
+
+
+def test_detect_gradle_settings_only(tmp_path):
+    (tmp_path / "settings.gradle.kts").write_text("")
+    assert "gradle" in audit.detect_ecosystems(str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# Maven — exact pins
+# ---------------------------------------------------------------------------
+
+POM_EXACT = """\
+<project>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>3.2.1</version>
+    </dependency>
+  </dependencies>
+</project>
+"""
+
+
+def test_maven_exact_pins_pass(tmp_path):
+    (tmp_path / "pom.xml").write_text(POM_EXACT)
+    result = audit.audit_maven(str(tmp_path))
+    assert result["exact_pins"]["status"] == "pass"
+
+
+def test_maven_range_detected(tmp_path):
+    pom = POM_EXACT.replace("<version>3.2.1</version>", "<version>[3.2,4.0)</version>")
+    (tmp_path / "pom.xml").write_text(pom)
+    result = audit.audit_maven(str(tmp_path))
+    assert result["exact_pins"]["status"] == "fail"
+    assert "[3.2,4.0)" in result["exact_pins"]["loose"]
+
+
+def test_maven_latest_detected(tmp_path):
+    pom = POM_EXACT.replace("<version>3.2.1</version>", "<version>LATEST</version>")
+    (tmp_path / "pom.xml").write_text(pom)
+    result = audit.audit_maven(str(tmp_path))
+    assert result["exact_pins"]["status"] == "fail"
+    assert "LATEST" in result["exact_pins"]["loose"]
+
+
+def test_maven_snapshot_detected(tmp_path):
+    pom = POM_EXACT.replace("<version>3.2.1</version>", "<version>3.2-SNAPSHOT</version>")
+    (tmp_path / "pom.xml").write_text(pom)
+    result = audit.audit_maven(str(tmp_path))
+    assert result["exact_pins"]["status"] == "fail"
+
+
+def test_maven_property_placeholder_not_flagged(tmp_path):
+    pom = POM_EXACT.replace("<version>3.2.1</version>", "<version>${spring.version}</version>")
+    (tmp_path / "pom.xml").write_text(pom)
+    result = audit.audit_maven(str(tmp_path))
+    assert result["exact_pins"]["status"] == "pass"
+
+
+# ---------------------------------------------------------------------------
+# Maven — enforcer plugin
+# ---------------------------------------------------------------------------
+
+POM_ENFORCER = """\
+<project>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.5.0</version>
+        <configuration>
+          <rules>
+            <banDynamicVersions/>
+            <requirePluginVersions/>
+            <requireReleaseDeps/>
+            <dependencyConvergence/>
+          </rules>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+"""
+
+
+def test_maven_enforcer_full_rules_pass(tmp_path):
+    (tmp_path / "pom.xml").write_text(POM_ENFORCER)
+    result = audit.audit_maven(str(tmp_path))
+    assert result["enforcer_plugin"]["status"] == "pass"
+    assert result["enforcer_plugin"]["ban_dynamic_versions"] is True
+    assert result["enforcer_plugin"]["dependency_convergence"] is True
+
+
+def test_maven_no_enforcer_fails(tmp_path):
+    (tmp_path / "pom.xml").write_text(POM_EXACT)
+    result = audit.audit_maven(str(tmp_path))
+    assert result["enforcer_plugin"]["status"] == "fail"
+    assert result["enforcer_plugin"]["present"] is False
+
+
+# ---------------------------------------------------------------------------
+# Maven — strict checksums
+# ---------------------------------------------------------------------------
+
+def test_maven_strict_checksums_in_pom(tmp_path):
+    pom = """<project><repositories><repository><id>x</id>
+    <releases><checksumPolicy>fail</checksumPolicy></releases>
+    </repository></repositories></project>"""
+    (tmp_path / "pom.xml").write_text(pom)
+    result = audit.audit_maven(str(tmp_path))
+    assert result["strict_checksums"]["status"] == "pass"
+    assert result["strict_checksums"]["in_pom"] is True
+
+
+def test_maven_strict_checksums_in_ci(tmp_path):
+    (tmp_path / "pom.xml").write_text(POM_EXACT)
+    make_workflow(tmp_path, "ci.yml", "steps:\n  - run: mvn --strict-checksums verify\n")
+    result = audit.audit_maven(str(tmp_path))
+    assert result["strict_checksums"]["in_ci"] is True
+    assert result["strict_checksums"]["status"] == "pass"
+
+
+def test_maven_no_strict_checksums_fails(tmp_path):
+    (tmp_path / "pom.xml").write_text(POM_EXACT)
+    result = audit.audit_maven(str(tmp_path))
+    assert result["strict_checksums"]["status"] == "fail"
+
+
+# ---------------------------------------------------------------------------
+# Maven — SCA scanner
+# ---------------------------------------------------------------------------
+
+def test_maven_sca_dependency_check(tmp_path):
+    pom = "<project><build><plugins><plugin>" \
+          "<artifactId>dependency-check-maven</artifactId></plugin></plugins></build></project>"
+    (tmp_path / "pom.xml").write_text(pom)
+    result = audit.audit_maven(str(tmp_path))
+    assert result["sca_scanner"]["status"] == "pass"
+    assert result["sca_scanner"]["owasp_dependency_check"] is True
+
+
+def test_maven_no_sca_scanner_fails(tmp_path):
+    (tmp_path / "pom.xml").write_text(POM_EXACT)
+    result = audit.audit_maven(str(tmp_path))
+    assert result["sca_scanner"]["status"] == "fail"
+
+
+# ---------------------------------------------------------------------------
+# Gradle — exact pins
+# ---------------------------------------------------------------------------
+
+BUILD_KTS_EXACT = """\
+plugins {
+    kotlin("jvm") version "1.9.22"
+}
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web:3.2.1")
+}
+"""
+
+
+def test_gradle_exact_pins_pass(tmp_path):
+    (tmp_path / "build.gradle.kts").write_text(BUILD_KTS_EXACT)
+    result = audit.audit_gradle(str(tmp_path))
+    assert result["exact_pins"]["status"] == "pass"
+
+
+def test_gradle_dynamic_plus_detected(tmp_path):
+    content = 'dependencies { implementation("g:n:1.+") }'
+    (tmp_path / "build.gradle.kts").write_text(content)
+    result = audit.audit_gradle(str(tmp_path))
+    assert result["exact_pins"]["status"] == "fail"
+
+
+def test_gradle_latest_release_detected(tmp_path):
+    content = 'dependencies { implementation("g:n:latest.release") }'
+    (tmp_path / "build.gradle.kts").write_text(content)
+    result = audit.audit_gradle(str(tmp_path))
+    assert result["exact_pins"]["status"] == "fail"
+
+
+def test_gradle_range_detected(tmp_path):
+    content = 'dependencies { implementation("g:n:[1.0,2.0)") }'
+    (tmp_path / "build.gradle.kts").write_text(content)
+    result = audit.audit_gradle(str(tmp_path))
+    assert result["exact_pins"]["status"] == "fail"
+
+
+def test_gradle_snapshot_detected(tmp_path):
+    content = 'dependencies { implementation("g:n:1.0-SNAPSHOT") }'
+    (tmp_path / "build.gradle.kts").write_text(content)
+    result = audit.audit_gradle(str(tmp_path))
+    assert result["exact_pins"]["status"] == "fail"
+
+
+# ---------------------------------------------------------------------------
+# Gradle — dependency locking
+# ---------------------------------------------------------------------------
+
+def test_gradle_dependency_locking_full(tmp_path):
+    content = """\
+allprojects {
+    dependencyLocking {
+        lockAllConfigurations()
+        lockMode.set(LockMode.STRICT)
+    }
+}
+"""
+    (tmp_path / "build.gradle.kts").write_text(content)
+    (tmp_path / "gradle.lockfile").write_text("# lockfile")
+    result = audit.audit_gradle(str(tmp_path))
+    assert result["dependency_locking"]["status"] == "pass"
+    assert result["dependency_locking"]["strict_mode"] is True
+
+
+def test_gradle_dependency_locking_missing(tmp_path):
+    (tmp_path / "build.gradle.kts").write_text(BUILD_KTS_EXACT)
+    result = audit.audit_gradle(str(tmp_path))
+    assert result["dependency_locking"]["status"] == "fail"
+
+
+def test_gradle_no_lockfile_present_fails(tmp_path):
+    content = """dependencyLocking { lockAllConfigurations() }"""
+    (tmp_path / "build.gradle.kts").write_text(content)
+    result = audit.audit_gradle(str(tmp_path))
+    assert result["dependency_locking"]["status"] == "fail"
+    assert result["dependency_locking"]["lockfile_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Gradle — verification metadata
+# ---------------------------------------------------------------------------
+
+def test_gradle_verification_metadata_pass(tmp_path):
+    (tmp_path / "build.gradle.kts").write_text("")
+    write_file(tmp_path, "gradle/verification-metadata.xml",
+               "<verification-metadata><configuration>"
+               "<verify-metadata>true</verify-metadata>"
+               "<verify-signatures>true</verify-signatures>"
+               "</configuration></verification-metadata>")
+    result = audit.audit_gradle(str(tmp_path))
+    assert result["dependency_verification"]["status"] == "pass"
+    assert result["dependency_verification"]["verify_signatures"] is True
+
+
+def test_gradle_verification_metadata_missing(tmp_path):
+    (tmp_path / "build.gradle.kts").write_text("")
+    result = audit.audit_gradle(str(tmp_path))
+    assert result["dependency_verification"]["status"] == "fail"
+    assert result["dependency_verification"]["file_present"] is False
+
+
+# ---------------------------------------------------------------------------
+# Gradle — wrapper SHA
+# ---------------------------------------------------------------------------
+
+def test_gradle_wrapper_sha_present(tmp_path):
+    (tmp_path / "build.gradle.kts").write_text("")
+    write_file(tmp_path, "gradle/wrapper/gradle-wrapper.properties",
+               "distributionUrl=https\\://services.gradle.org/distributions/gradle-8.10.2-bin.zip\n"
+               "distributionSha256Sum=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26\n")
+    result = audit.audit_gradle(str(tmp_path))
+    assert result["wrapper"]["status"] == "pass"
+    assert result["wrapper"]["distribution_sha256"] is True
+
+
+def test_gradle_wrapper_sha_missing(tmp_path):
+    (tmp_path / "build.gradle.kts").write_text("")
+    write_file(tmp_path, "gradle/wrapper/gradle-wrapper.properties",
+               "distributionUrl=https\\://services.gradle.org/distributions/gradle-8.10.2-bin.zip\n")
+    result = audit.audit_gradle(str(tmp_path))
+    assert result["wrapper"]["status"] == "fail"
+    assert result["wrapper"]["distribution_sha256"] is False
+
+
+# ---------------------------------------------------------------------------
+# Gradle — repository control
+# ---------------------------------------------------------------------------
+
+def test_gradle_repo_control_pass(tmp_path):
+    content = """\
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+    }
+}
+"""
+    (tmp_path / "settings.gradle.kts").write_text(content)
+    result = audit.audit_gradle(str(tmp_path))
+    assert result["repository_control"]["status"] == "pass"
+
+
+def test_gradle_maven_local_flagged(tmp_path):
+    content = """\
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+}
+"""
+    (tmp_path / "settings.gradle.kts").write_text(content)
+    result = audit.audit_gradle(str(tmp_path))
+    assert result["repository_control"]["status"] == "fail"
+    assert result["repository_control"]["uses_mavenLocal"] is True
+
+
+def test_gradle_jcenter_flagged(tmp_path):
+    content = """\
+repositories {
+    jcenter()
+}
+"""
+    (tmp_path / "build.gradle.kts").write_text(content)
+    result = audit.audit_gradle(str(tmp_path))
+    assert result["repository_control"]["uses_jcenter"] is True
+    assert result["repository_control"]["status"] == "fail"
+
+
+# ---------------------------------------------------------------------------
+# Gradle — reject dynamic resolution
+# ---------------------------------------------------------------------------
+
+def test_gradle_failOnNonReproducible_pass(tmp_path):
+    content = """\
+configurations.all {
+    resolutionStrategy {
+        failOnNonReproducibleResolution()
+    }
+}
+"""
+    (tmp_path / "build.gradle.kts").write_text(content)
+    result = audit.audit_gradle(str(tmp_path))
+    assert result["reject_dynamic"]["status"] == "pass"
+
+
+def test_gradle_no_reject_dynamic_fails(tmp_path):
+    (tmp_path / "build.gradle.kts").write_text(BUILD_KTS_EXACT)
+    result = audit.audit_gradle(str(tmp_path))
+    assert result["reject_dynamic"]["status"] == "fail"
+
+
+# ---------------------------------------------------------------------------
+# Gradle — CI
+# ---------------------------------------------------------------------------
+
+def test_gradle_ci_uses_wrapper_pass(tmp_path):
+    (tmp_path / "build.gradle.kts").write_text("")
+    make_workflow(tmp_path, "ci.yml", "steps:\n  - run: ./gradlew --no-daemon build\n")
+    result = audit.audit_gradle(str(tmp_path))
+    assert result["ci"]["uses_wrapper"] is True
+    assert result["ci"]["status"] == "pass"
+
+
+def test_gradle_ci_writes_locks_fails(tmp_path):
+    (tmp_path / "build.gradle.kts").write_text("")
+    make_workflow(tmp_path, "ci.yml",
+                  "steps:\n  - run: ./gradlew dependencies --write-locks\n")
+    result = audit.audit_gradle(str(tmp_path))
+    assert result["ci"]["writes_locks_in_ci"] is True
+    assert result["ci"]["status"] == "fail"
+
+
+# ---------------------------------------------------------------------------
+# Dependabot integration
+# ---------------------------------------------------------------------------
+
+def test_dependabot_maven_cooldown(tmp_path):
+    (tmp_path / "pom.xml").write_text(POM_EXACT)
+    write_file(tmp_path, ".github/dependabot.yml", """\
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+""")
+    result = audit.audit_dependabot(str(tmp_path), ["maven"])
+    assert result["ecosystems"]["maven"]["status"] == "pass"
+
+
+def test_dependabot_gradle_wrapper_subfinding(tmp_path):
+    (tmp_path / "build.gradle.kts").write_text("")
+    write_file(tmp_path, ".github/dependabot.yml", """\
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "gradle-wrapper"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+""")
+    result = audit.audit_dependabot(str(tmp_path), ["gradle"])
+    assert result["ecosystems"]["gradle"]["status"] == "pass"
+    assert result["ecosystems"]["gradle"]["gradle_wrapper_ecosystem"] == "pass"
+
+
+def test_dependabot_gradle_wrapper_missing(tmp_path):
+    (tmp_path / "build.gradle.kts").write_text("")
+    write_file(tmp_path, ".github/dependabot.yml", """\
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+""")
+    result = audit.audit_dependabot(str(tmp_path), ["gradle"])
+    assert result["ecosystems"]["gradle"]["gradle_wrapper_ecosystem"] == "missing"


### PR DESCRIPTION
## Summary
- Adds `docs/jvm.md` covering Maven and Gradle (Java, Kotlin, brief sbt note): exact pinning, Maven Enforcer rules as the lockfile substitute, Gradle `dependencyLocking` + `verification-metadata.xml`, Gradle Wrapper SHA pinning, repository control / dependency-confusion defence, plugin-execution risk, Dependabot cooldowns, and Harden-Runner egress allowlists.
- Adds `agents/AGENTS-jvm.md` with matching mandatory rules and a "what requires human review" section.
- Updates `README.md`: contents table, Quick Start curl list, Minimum Release Age matrix (both ❌, mitigated via Dependabot + enforcer/locking), Version Constraint Support table with a new footnote explaining Maven's no-native-lockfile gap, and reference links (Maven, Gradle, OWASP DC, CycloneDX, OSS Index, `maven-lockfile`).