### PR TITLE
docs: SHA-pin step-security/harden-runner references

### DIFF
--- a/agents/AGENTS-helm.md
+++ b/agents/AGENTS-helm.md
@@ -124,7 +124,7 @@ Dependabot does **not** manage Helm chart dependencies. It can manage container 
 Every GitHub Actions workflow that fetches Helm charts must include `step-security/harden-runner` as its first step. New workflows must not be added without it. Allowed endpoints must include the chart repositories and OCI registries the project depends on:
 
 ```yaml
-- uses: step-security/harden-runner@v2
+- uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2
   with:
     egress-policy: block
     disable-sudo: true

--- a/agents/AGENTS-nodejs.md
+++ b/agents/AGENTS-nodejs.md
@@ -116,7 +116,7 @@ Every GitHub Actions workflow that installs dependencies must include `step-secu
 Start in `audit` mode for new workflows, then tighten to `block` once the egress policy is stable:
 
 ```yaml
-- uses: step-security/harden-runner@v2
+- uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2
   with:
     egress-policy: block
     disable-sudo: true

--- a/agents/AGENTS-php.md
+++ b/agents/AGENTS-php.md
@@ -93,7 +93,7 @@ Every GitHub Actions workflow that runs `composer install` must include `step-se
 Start in `audit` mode for new workflows, then tighten to `block` once the egress policy is stable:
 
 ```yaml
-- uses: step-security/harden-runner@v2
+- uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2
   with:
     egress-policy: block
     disable-sudo: true

--- a/agents/AGENTS-python.md
+++ b/agents/AGENTS-python.md
@@ -113,7 +113,7 @@ Every GitHub Actions workflow that installs dependencies must include `step-secu
 Start in `audit` mode for new workflows, then tighten to `block` once the egress policy is stable:
 
 ```yaml
-- uses: step-security/harden-runner@v2
+- uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2
   with:
     egress-policy: block
     disable-sudo: true

--- a/agents/AGENTS-ruby.md
+++ b/agents/AGENTS-ruby.md
@@ -87,7 +87,7 @@ Every GitHub Actions workflow that runs `bundle install` must include `step-secu
 Start in `audit` mode for new workflows, then tighten to `block` once the egress policy is stable:
 
 ```yaml
-- uses: step-security/harden-runner@v2
+- uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2
   with:
     egress-policy: block
     disable-sudo: true

--- a/agents/AGENTS-rust.md
+++ b/agents/AGENTS-rust.md
@@ -120,7 +120,7 @@ Every GitHub Actions workflow that fetches crates must include `step-security/ha
 Start in `audit` mode for new workflows, then tighten to `block` once the egress policy is stable:
 
 ```yaml
-- uses: step-security/harden-runner@v2
+- uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2
   with:
     egress-policy: block
     disable-sudo: true

--- a/agents/AGENTS-terraform.md
+++ b/agents/AGENTS-terraform.md
@@ -155,7 +155,7 @@ Every GitHub Actions workflow that runs `terraform init` or `tofu init` must inc
 Start in `audit` mode for new workflows, then tighten to `block` once the egress policy is stable:
 
 ```yaml
-- uses: step-security/harden-runner@v2
+- uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2
   with:
     egress-policy: block
     disable-sudo: true

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -68,7 +68,7 @@ See [harden-runner.md](harden-runner.md) for full configuration guidance. The sh
 
 ```yaml
 steps:
-  - uses: step-security/harden-runner@bb774aa972c2a89ff34781233d275075cbddf542 # v2
+  - uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2
     with:
       egress-policy: block
       disable-sudo: true

--- a/docs/harden-runner.md
+++ b/docs/harden-runner.md
@@ -15,7 +15,7 @@ Start every new workflow in `audit` mode to observe what outbound connections ar
 ```yaml
 # .github/workflows/ci.yml
 steps:
-  - uses: step-security/harden-runner@v2
+  - uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2
     with:
       egress-policy: audit   # start here; switch to 'block' once allowlist is stable
       disable-sudo: true     # prevent privilege escalation on the runner
@@ -28,7 +28,7 @@ Once the egress policy is stable, switch to `block` and enumerate only the endpo
 **Node.js (npm / pnpm / yarn / bun):**
 
 ```yaml
-- uses: step-security/harden-runner@v2
+- uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2
   with:
     egress-policy: block
     disable-sudo: true
@@ -43,7 +43,7 @@ Once the egress policy is stable, switch to `block` and enumerate only the endpo
 **Python (pip / uv):**
 
 ```yaml
-- uses: step-security/harden-runner@v2
+- uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2
   with:
     egress-policy: block
     disable-sudo: true
@@ -58,7 +58,7 @@ Once the egress policy is stable, switch to `block` and enumerate only the endpo
 **Go:**
 
 ```yaml
-- uses: step-security/harden-runner@v2
+- uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2
   with:
     egress-policy: block
     disable-sudo: true
@@ -74,7 +74,7 @@ Once the egress policy is stable, switch to `block` and enumerate only the endpo
 **Cargo (Rust):**
 
 ```yaml
-- uses: step-security/harden-runner@v2
+- uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2
   with:
     egress-policy: block
     disable-sudo: true

--- a/docs/php.md
+++ b/docs/php.md
@@ -181,7 +181,7 @@ updates:
 Every workflow that runs `composer install` must include `step-security/harden-runner`:
 
 ```yaml
-- uses: step-security/harden-runner@v2
+- uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2
   with:
     egress-policy: block
     disable-sudo: true

--- a/docs/ruby.md
+++ b/docs/ruby.md
@@ -162,7 +162,7 @@ Security update PRs from Dependabot bypass the cooldown automatically and should
 Every GitHub Actions workflow that runs `bundle install` must include `step-security/harden-runner`:
 
 ```yaml
-- uses: step-security/harden-runner@v2
+- uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2
   with:
     egress-policy: block
     disable-sudo: true

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -122,7 +122,7 @@ updates:
 ### Harden-Runner
 
 ```yaml
-- uses: step-security/harden-runner@v2
+- uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2
   with:
     egress-policy: block
     disable-sudo: true


### PR DESCRIPTION
## Summary
- Replace mutable `step-security/harden-runner@v2` references with the SHA pin already in use in `.github/workflows/ci.yml` (`@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2`).
- Aligns docs and agent rulesets with this repo's core guidance on SHA-pinning third-party actions, so readers copying examples don't inherit an unpinned ref.
- Also bumps `docs/github-actions.md` from the older `bb774aa…` SHA to the same newer SHA used in CI, for consistency.

## Files
- `docs/github-actions.md`, `docs/harden-runner.md`, `docs/php.md`, `docs/ruby.md`, `docs/terraform.md`
- `agents/AGENTS-{python,php,terraform,helm,rust,ruby,nodejs}.md`

Intentionally untouched: `agents/AGENTS-github-actions.md` and `agents/AGENTS-go.md` use `<sha>` / `<SHA>` placeholders by design.