### PR TITLE
docs: propagate uv/Dependabot/harden-runner findings from session

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The lockfile provides a partial mitigation — it pins exact resolved versions �
 | [Yarn Classic](docs/nodejs.md#yarn-classic) / [Berry](docs/nodejs.md#yarn-berry) | `^` (minor+patch) | `^1.0.0` `~1.0.0` `>=1.0.0` | `1.0.0` | ✅ Yes — `--immutable` | `defaultSemverRangePrefix: ""` in `.yarnrc.yml` |
 | [Bun](docs/nodejs.md#bun) | `^` (minor+patch) | `^1.0.0` `~1.0.0` `>=1.0.0` | `1.0.0` | ✅ Yes — `--frozen-lockfile` | `exact = true` in `bunfig.toml` |
 | [pip](docs/python.md#pip) | None (user-specified) | `>=1.0.0` `~=1.0.0` `!=1.0.0` | `==1.0.0` | ❌ No native lockfile | `pip-compile --generate-hashes`; always use `==` |
-| [uv](docs/python.md#uv) | None (user-specified) | `>=1.0.0` `~=1.0.0` | `==1.0.0` | ✅ Yes — `uv sync --frozen` | `require-hashes = true` in `[tool.uv]` |
+| [uv](docs/python.md#uv) | None (user-specified) | `>=1.0.0` `~=1.0.0` | `==1.0.0` | ✅ Yes — `uv sync --frozen` (auto-verifies hashes from `uv.lock`) | `require-hashes = true` in `[tool.uv.pip]` (defensive, for ad-hoc `uv pip install`) |
 | [Go modules](docs/go.md#go-modules) | MVS minimum¹ | `@latest` `@master` | `@v1.9.1` | ✅ Yes — `go.sum` hashes | Never use `@latest`; always specify a tagged version |
 | [Cargo](docs/rust.md#cargo-rust) | `^` (caret, implicit) | `1.0.0` `^1.0.0` `~1.0.0` `>=1.0.0` | `=1.0.0` | ✅ Yes — `--locked` | Use `=` prefix explicitly in `Cargo.toml` |
 | [Composer](docs/php.md#composer) | `^` (caret) | `^1.2.3` `~1.2.3` `>=1.0` `1.2.*` | `1.2.3` | ✅ Yes — `composer install` enforces it | Use bare version strings in `composer.json` |

--- a/agents/AGENTS-github-actions.md
+++ b/agents/AGENTS-github-actions.md
@@ -65,6 +65,8 @@ steps:
 
 Add ecosystem-specific endpoints as needed (e.g. `pypi.org:443 files.pythonhosted.org:443` for Python jobs, `registry.npmjs.org:443` for Node.js jobs).
 
+For any action that downloads a binary from a GitHub release (e.g. `astral-sh/setup-uv`, `opentofu/setup-opentofu`), also allow `release-assets.githubusercontent.com:443` — modern GitHub release downloads redirect through that host. The older `github-production-release-asset-2e65be.s3.amazonaws.com` is deprecated and will fail with `ECONNREFUSED` in `block` mode.
+
 **Exception:** jobs that fetch arbitrary external URLs (link checkers, scanners) must use `egress-policy: audit` since a fixed allowlist cannot be constructed. Add a comment explaining why.
 
 Start new jobs in `audit` mode and tighten to `block` once the allowlist is confirmed from the audit logs.
@@ -83,6 +85,8 @@ Pin all tool installs in CI steps to exact versions. Do not use bare installs:
 - run: pip install ruff
 - run: npx --yes markdownlint-cli2
 ```
+
+**Dependabot blind spot:** inline `pip install x==y` / `npm install x@y` lines in workflow files are pinned but **not parsed by Dependabot** — no ecosystem will open update PRs for them, and they silently rot. For tools used by CI, prefer declaring them in a manifest Dependabot understands (e.g. `pyproject.toml [dependency-groups]` for Python, `package.json` `devDependencies` for Node) and invoking via `uv run` / `npx` from the locked install. Inline pins are acceptable only as a short-term measure with a tracked follow-up.
 
 ## Expression Injection
 

--- a/agents/AGENTS-github-actions.md
+++ b/agents/AGENTS-github-actions.md
@@ -67,6 +67,8 @@ Add ecosystem-specific endpoints as needed (e.g. `pypi.org:443 files.pythonhoste
 
 For any action that downloads a binary from a GitHub release (e.g. `astral-sh/setup-uv`, `opentofu/setup-opentofu`), also allow `release-assets.githubusercontent.com:443` — modern GitHub release downloads redirect through that host. The older `github-production-release-asset-2e65be.s3.amazonaws.com` is deprecated and will fail with `ECONNREFUSED` in `block` mode.
 
+Some actions also fetch a runtime version manifest from `raw.githubusercontent.com`. Notable case: `astral-sh/setup-uv` **v8+** reads `https://raw.githubusercontent.com/astral-sh/versions/main/v1/uv.ndjson` on every run; v6.x did not. A Dependabot bump that crosses this boundary will fail in `block` mode until `raw.githubusercontent.com:443` is added. Always re-validate the allowlist when an action crosses a major version.
+
 **Exception:** jobs that fetch arbitrary external URLs (link checkers, scanners) must use `egress-policy: audit` since a fixed allowlist cannot be constructed. Add a comment explaining why.
 
 Start new jobs in `audit` mode and tighten to `block` once the allowlist is confirmed from the audit logs.

--- a/agents/AGENTS-python.md
+++ b/agents/AGENTS-python.md
@@ -125,9 +125,14 @@ Start in `audit` mode for new workflows, then tighten to `block` once the egress
       files.pythonhosted.org:443
       astral.sh:443
       release-assets.githubusercontent.com:443
+      raw.githubusercontent.com:443
 ```
 
-The last two endpoints are required only when `astral-sh/setup-uv` runs. GitHub release downloads now redirect through `release-assets.githubusercontent.com`; the older `github-production-release-asset-2e65be.s3.amazonaws.com` host is deprecated and will fail with `ECONNREFUSED` in `block` mode.
+The last three endpoints are required only when `astral-sh/setup-uv` runs:
+
+- `astral.sh` — managed Python downloads.
+- `release-assets.githubusercontent.com` — modern GitHub release-asset CDN (the uv binary). The older `github-production-release-asset-2e65be.s3.amazonaws.com` is deprecated and will fail with `ECONNREFUSED` in `block` mode.
+- `raw.githubusercontent.com` — **v8+ only**. `setup-uv` v8 fetches its version manifest from `https://raw.githubusercontent.com/astral-sh/versions/main/v1/uv.ndjson`; v6.x did not need this endpoint, so a Dependabot bump from v6 → v8 will fail until it is added.
 
 ## What Requires Human Review
 

--- a/agents/AGENTS-python.md
+++ b/agents/AGENTS-python.md
@@ -123,7 +123,11 @@ Start in `audit` mode for new workflows, then tighten to `block` once the egress
       objects.githubusercontent.com:443
       pypi.org:443
       files.pythonhosted.org:443
+      astral.sh:443
+      release-assets.githubusercontent.com:443
 ```
+
+The last two endpoints are required only when `astral-sh/setup-uv` runs. GitHub release downloads now redirect through `release-assets.githubusercontent.com`; the older `github-production-release-asset-2e65be.s3.amazonaws.com` host is deprecated and will fail with `ECONNREFUSED` in `block` mode.
 
 ## What Requires Human Review
 
@@ -132,6 +136,6 @@ The following changes must not be made autonomously and require explicit human a
 - Adding a new dependency with no prior entry in the lockfile
 - Upgrading a major version
 - Disabling or removing `exclude-newer` from `[tool.uv]`
-- Removing `require-hashes` or `verify-hashes`
+- Removing `require-hashes` or `verify-hashes` from `[tool.uv.pip]`
 - Modifying `.github/dependabot.yml` cooldown values downward
 - Removing or modifying Harden-Runner from a workflow

--- a/docs/dependabot.md
+++ b/docs/dependabot.md
@@ -29,6 +29,20 @@ updates:
     cooldown:
       default-days: 7
 
+  # uv reads pyproject.toml [project.dependencies] and [dependency-groups].
+  # Inline `pip install x==y` lines in workflow files are NOT updated by
+  # any ecosystem — move dev tooling into a [dependency-groups] entry to
+  # make it visible to Dependabot.
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:

--- a/docs/harden-runner.md
+++ b/docs/harden-runner.md
@@ -60,9 +60,12 @@ If the workflow uses `astral-sh/setup-uv` (or any action that downloads a binary
 ```yaml
       astral.sh:443
       release-assets.githubusercontent.com:443
+      raw.githubusercontent.com:443
 ```
 
-GitHub release downloads now redirect through `release-assets.githubusercontent.com`. Older allowlists may reference `github-production-release-asset-2e65be.s3.amazonaws.com` — that host is deprecated for new release downloads and will fail with `ECONNREFUSED` in `block` mode.
+`release-assets.githubusercontent.com` is the modern GitHub release-asset CDN. Older allowlists may reference `github-production-release-asset-2e65be.s3.amazonaws.com` — that host is deprecated for new release downloads and will fail with `ECONNREFUSED` in `block` mode.
+
+`raw.githubusercontent.com` is required for `astral-sh/setup-uv` **v8+** specifically: v8 refactored version resolution to fetch `https://raw.githubusercontent.com/astral-sh/versions/main/v1/uv.ndjson` at runtime. v6.x baked the manifest into the action and did not need this endpoint, so workflows upgrading from v6 to v8 will fail until the endpoint is added.
 
 **Go:**
 

--- a/docs/harden-runner.md
+++ b/docs/harden-runner.md
@@ -55,6 +55,15 @@ Once the egress policy is stable, switch to `block` and enumerate only the endpo
       files.pythonhosted.org:443
 ```
 
+If the workflow uses `astral-sh/setup-uv` (or any action that downloads a binary from a GitHub release), add:
+
+```yaml
+      astral.sh:443
+      release-assets.githubusercontent.com:443
+```
+
+GitHub release downloads now redirect through `release-assets.githubusercontent.com`. Older allowlists may reference `github-production-release-asset-2e65be.s3.amazonaws.com` — that host is deprecated for new release downloads and will fail with `ECONNREFUSED` in `block` mode.
+
 **Go:**
 
 ```yaml

--- a/docs/python.md
+++ b/docs/python.md
@@ -272,9 +272,13 @@ allowed-endpoints: >
   files.pythonhosted.org:443
   astral.sh:443
   release-assets.githubusercontent.com:443
+  raw.githubusercontent.com:443
 ```
 
-Note: GitHub release downloads now redirect through `release-assets.githubusercontent.com`. Older guides that list `github-production-release-asset-2e65be.s3.amazonaws.com` are out of date.
+Notes:
+
+- GitHub release downloads now redirect through `release-assets.githubusercontent.com`. Older guides that list `github-production-release-asset-2e65be.s3.amazonaws.com` are out of date.
+- `raw.githubusercontent.com` is needed by `astral-sh/setup-uv` **v8+** only: v8 fetches its version manifest from `https://raw.githubusercontent.com/astral-sh/versions/main/v1/uv.ndjson`. v6.x baked the manifest into the action; workflows upgrading from v6 to v8 will fail until this endpoint is added.
 
 Audit dependencies separately:
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -126,15 +126,17 @@ dependencies = [
 ]
 ```
 
-For development dependencies:
+For development dependencies, prefer PEP 735 dependency groups (supported by uv since 0.5.x) over the older uv-specific `[tool.uv].dev-dependencies` form:
 
 ```toml
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
   "pytest==8.1.0",
   "ruff==0.4.0",
 ]
 ```
+
+Install with `uv sync --group dev` (or `--all-groups`). Dependabot's `uv` ecosystem reads `[dependency-groups]` and will open update PRs for entries declared there — inline `pip install x==y` lines in workflow files are invisible to Dependabot.
 
 ### Registry / Index Configuration
 
@@ -203,11 +205,15 @@ exclude-newer = "0 days"   # bypass cooldown for this package
 
 ### Security: Hash Verification
 
+When installing from `uv.lock` via `uv sync --frozen`, hash verification is **automatic and unconditional** — every wheel/sdist resolved from the lockfile is checked against the sha256 recorded at lock time. No additional flag is required, and the lockfile must be committed for this to work.
+
+The `require-hashes` / `verify-hashes` knobs live under `[tool.uv.pip]` (not `[tool.uv]` — uv rejects them at the top level) and only apply to ad-hoc `uv pip install` invocations that bypass the project workflow:
+
 ```toml
 # pyproject.toml
-[tool.uv]
-require-hashes = true        # all dependencies must have hash entries in lockfile
-verify-hashes = true         # verify hashes at install time (default: true)
+[tool.uv.pip]
+require-hashes = true        # uv pip install: every dep must carry a hash
+verify-hashes = true         # uv pip install: verify hashes at install time
 ```
 
 ### Security: Disabling Build Scripts
@@ -238,8 +244,39 @@ uv run --package myapi pytest  # run in specific workspace member
 # pyproject.toml
 [tool.uv]
 exclude-newer = "7 days"
+
+[tool.uv.pip]
 require-hashes = true
+verify-hashes = true
 ```
+
+In the workflow, install uv via the official action (SHA-pinned with the dereferenced annotated-tag commit, plus a `version:` pin so the runtime matches local development):
+
+```yaml
+- uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+  with:
+    version: "0.11.11"
+
+- run: uv sync --frozen --group dev --python 3.12
+- run: uv run pytest
+```
+
+Harden-Runner allowlist must include the uv binary download path:
+
+```yaml
+allowed-endpoints: >
+  api.github.com:443
+  github.com:443
+  objects.githubusercontent.com:443
+  pypi.org:443
+  files.pythonhosted.org:443
+  astral.sh:443
+  release-assets.githubusercontent.com:443
+```
+
+Note: GitHub release downloads now redirect through `release-assets.githubusercontent.com`. Older guides that list `github-production-release-asset-2e65be.s3.amazonaws.com` are out of date.
+
+Audit dependencies separately:
 
 ```bash
 uv sync --frozen

--- a/skills/harden-packages/SKILL.md
+++ b/skills/harden-packages/SKILL.md
@@ -486,7 +486,7 @@ terraform providers lock \
 Append the ecosystem-specific endpoints:
 
 - Node.js: `registry.npmjs.org:443` (add `npm.pkg.github.com:443` if GitHub Packages used)
-- Python: `pypi.org:443 files.pythonhosted.org:443` (add `astral.sh:443 release-assets.githubusercontent.com:443` if `astral-sh/setup-uv` is used — it downloads the uv binary from GitHub releases, which redirect to `release-assets.githubusercontent.com`, **not** the older `github-production-release-asset-2e65be.s3.amazonaws.com`)
+- Python: `pypi.org:443 files.pythonhosted.org:443` (add `astral.sh:443 release-assets.githubusercontent.com:443 raw.githubusercontent.com:443` if `astral-sh/setup-uv` is used — it downloads the uv binary from GitHub releases (which redirect to `release-assets.githubusercontent.com`, **not** the older `github-production-release-asset-2e65be.s3.amazonaws.com`), and on **v8+** also fetches its version manifest from `raw.githubusercontent.com/astral-sh/versions`. v6.x baked the manifest into the action and did not need `raw.githubusercontent.com`.)
 - Go: `proxy.golang.org:443 sum.golang.org:443 storage.googleapis.com:443`
 - Rust: `crates.io:443 index.crates.io:443 static.crates.io:443`
 - PHP: `packagist.org:443 repo.packagist.org:443`

--- a/skills/harden-packages/SKILL.md
+++ b/skills/harden-packages/SKILL.md
@@ -102,9 +102,9 @@ Example report structure:
 ⚠️ onlyBuiltDependencies not configured — all installed packages can run postinstall scripts
 
 ### Python (uv)
-✅ uv.lock committed
+✅ uv.lock committed (hash verification is automatic with `uv sync --frozen`)
 ✅ exclude-newer = "7 days"
-❌ require-hashes not set — packages are not hash-verified on install
+❌ [tool.uv.pip] require-hashes not set — ad-hoc `uv pip install` calls won't enforce hashes
 
 ### Dependabot
 ✅ npm cooldown configured (7/30/7/3 days)
@@ -117,7 +117,7 @@ Example report structure:
 ### Priority fixes
 1. Add harden-runner to release.yml — release workflows are high-value targets
 2. Set egress-policy: block in ci.yml once allowlist is confirmed
-3. Add require-hashes = true to [tool.uv]
+3. Add require-hashes = true under [tool.uv.pip] (defensive, for ad-hoc `uv pip install`)
 4. Add pip entry to dependabot.yml
 5. Set trustPolicy: no-downgrade in pnpm-workspace.yaml
 ```
@@ -129,7 +129,7 @@ After the report, ask: "Would you like me to apply the fixes? I can handle all o
 If the user agrees (fully or partially), apply the fixes in this order — lower risk / non-breaking changes first:
 
 1. `pnpm-workspace.yaml` / `.npmrc` / `.yarnrc.yml` / `bunfig.toml` — add missing cooldown / trust policy config
-2. `pyproject.toml [tool.uv]` — add `exclude-newer`, `require-hashes`, `verify-hashes`
+2. `pyproject.toml` — add `[tool.uv] exclude-newer = "7 days"` and `[tool.uv.pip] require-hashes = true / verify-hashes = true`. (Hash verification of artefacts resolved against `uv.lock` is automatic via `uv sync --frozen` — these `[tool.uv.pip]` flags only protect ad-hoc `uv pip install` invocations.)
 3. `.cargo/config.toml` — add `[cooldown]` block
 4. `composer.json` — add `roave/security-advisories` dev dependency; tighten `^`/`~` pins to exact (flag for human review)
 5. Ruby CI — add `BUNDLE_FROZEN=true` and `bundle audit check` to CI workflow
@@ -179,10 +179,29 @@ lifecycleScripts = false
 
 ```toml
 [tool.uv]
+# Rolling 7-day cooldown — re-evaluated on every `uv lock`.
+# Supported since uv 0.9.17 (Dec 2025).
 exclude-newer = "7 days"
+
+[tool.uv.pip]
+# Defensive: enforce hashes for ad-hoc `uv pip install` calls.
+# `uv sync --frozen` already enforces lockfile hashes automatically;
+# these flags only affect the pip-compat surface.
 require-hashes = true
 verify-hashes = true
 ```
+
+**Note on dev tooling:** declare ruff/pytest/etc. as a PEP 735 dependency group, not as inline `pip install` lines in CI — Dependabot (`package-ecosystem: "uv"`) cannot update what isn't in a manifest:
+
+```toml
+[dependency-groups]
+dev = [
+  "ruff==0.11.2",
+  "pytest==8.3.5",
+]
+```
+
+Then install in CI with `uv sync --frozen --group dev` and run via `uv run <tool>`.
 
 **Cargo .cargo/config.toml additions:**
 
@@ -467,7 +486,7 @@ terraform providers lock \
 Append the ecosystem-specific endpoints:
 
 - Node.js: `registry.npmjs.org:443` (add `npm.pkg.github.com:443` if GitHub Packages used)
-- Python: `pypi.org:443 files.pythonhosted.org:443`
+- Python: `pypi.org:443 files.pythonhosted.org:443` (add `astral.sh:443 release-assets.githubusercontent.com:443` if `astral-sh/setup-uv` is used — it downloads the uv binary from GitHub releases, which redirect to `release-assets.githubusercontent.com`, **not** the older `github-production-release-asset-2e65be.s3.amazonaws.com`)
 - Go: `proxy.golang.org:443 sum.golang.org:443 storage.googleapis.com:443`
 - Rust: `crates.io:443 index.crates.io:443 static.crates.io:443`
 - PHP: `packagist.org:443 repo.packagist.org:443`
@@ -506,7 +525,7 @@ Use this section only if `audit.py` cannot be run. It replicates what the script
 
 ### Python (pip / uv)
 
-- uv: is `uv.lock` present and not gitignored? Are `exclude-newer`, `require-hashes`, `verify-hashes` set in `[tool.uv]`?
+- uv: is `uv.lock` present and **not gitignored**? Is `exclude-newer` set in `[tool.uv]` (rolling duration like `"7 days"` preferred over a frozen timestamp)? Are `require-hashes` and `verify-hashes` set in `[tool.uv.pip]` (note: this is `[tool.uv.pip]`, not `[tool.uv]` — uv rejects them at the top level)? Hash verification against `uv.lock` is automatic via `uv sync --frozen` regardless. Are dev tools (ruff/pytest/etc.) declared in `[dependency-groups]` so Dependabot can update them, rather than inline `pip install x==y` in CI?
 - pip: is there a `requirements.lock` with hashes (from `pip-compile --generate-hashes`)?
 - Are all package specs using `==` (not `>=`, `~=`, or unpinned)?
 - uv: does CI use `uv sync --frozen`? pip: `pip install --require-hashes`?


### PR DESCRIPTION
## Summary

Rolls back into the skill, docs, and AGENTS files the lessons that surfaced while wiring up uv-managed Python tooling and Dependabot coverage on this repo (PR #3). These were all real gotchas where the existing guidance would have led the next user/agent into the same dead ends.

## Findings propagated

### 1. `[tool.uv.pip]` vs `[tool.uv]` for hash flags

`require-hashes` and `verify-hashes` are **rejected by uv at the `[tool.uv]` top level** with `unknown field`. They live under `[tool.uv.pip]` and only affect ad-hoc `uv pip install` calls — hash verification of artefacts resolved against `uv.lock` is automatic when CI runs `uv sync --frozen` (the lockfile contains sha256s that are checked unconditionally).

The previous skill template, docs, and AGENTS file all put these keys under `[tool.uv]`, which would fail on first `uv lock`.

**Fixed in:** `skills/harden-packages/SKILL.md` (template, audit checklist line, interpretation note, fix-order step), `docs/python.md`, `agents/AGENTS-python.md`, `README.md`.

### 2. PEP 735 dependency groups for dev tooling

Inline `pip install ruff==X` lines in CI are pinned-but-invisible to Dependabot — no ecosystem will update them, and they silently rot. Dev tools should live in `pyproject.toml [dependency-groups].dev` so the `uv` ecosystem can see and bump them, then be invoked via `uv run` in CI.

The old `docs/python.md` example showed `[tool.uv].dev-dependencies` (the older uv-specific form); switched to PEP 735.

**Documented in:** `SKILL.md`, `docs/python.md`, `agents/AGENTS-python.md`, plus a new "Dependabot blind spot" callout in `agents/AGENTS-github-actions.md`.

### 3. `astral-sh/setup-uv` + harden-runner allowlist

GitHub release downloads now redirect through `release-assets.githubusercontent.com`, **not** the deprecated `github-production-release-asset-2e65be.s3.amazonaws.com`. block-mode Harden-Runner without the new host fails with `ECONNREFUSED` (this is exactly what tripped PR #3's first CI run).

Added the correct endpoints plus a SHA-pinned setup-uv example to: `docs/harden-runner.md`, `docs/python.md`, `agents/AGENTS-python.md`, `agents/AGENTS-github-actions.md`, `SKILL.md`.

### 4. Dependabot `uv` ecosystem template

`docs/dependabot.md` only had a `pip` example. Added a `uv` ecosystem block alongside it with the rationale about workflow-inline installs being invisible.

## Verification

- `uv run ruff check skills/harden-packages/audit.py` — clean
- `uv run ruff format --check` — clean
- `uv run pytest tests/ -q` — 202/202 passing
- `reuse lint` — 50/50 files compliant
- `markdownlint-cli2 "**/*.md"` — 28 files, 0 errors

No code changes — documentation, skill template, and agent-instruction files only. Audit script (`audit.py`) regex matchers are scope-agnostic and continue to work correctly with the new `[tool.uv.pip]` placement.

🤖 Generated with [pi](https://github.com/badlogic/lemmy/tree/main/apps/pi)
