### PR TITLE
ci+docs: add zizmor static analysis and address its findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ on:
     branches: [main]
   pull_request:
 
+# Cancel superseded runs on the same ref to save Actions minutes and
+# avoid stacking concurrent jobs (zizmor: concurrency-limits).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Least-privilege baseline: all jobs get read-only contents unless overridden.
 permissions:
   contents: read
@@ -28,6 +34,8 @@ jobs:
             objects.githubusercontent.com:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6.0.0
 
@@ -50,6 +58,8 @@ jobs:
             raw.githubusercontent.com:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
@@ -81,13 +91,19 @@ jobs:
             raw.githubusercontent.com:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.11.11"
 
-      - run: uv sync --frozen --group dev --python ${{ matrix.python-version }}
-      - run: uv run pytest tests/ -v
+      # Pass matrix value via env to avoid template-injection in `run:` (zizmor).
+      - env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
+        run: |
+          uv sync --frozen --group dev --python "$PYTHON_VERSION"
+          uv run pytest tests/ -v
 
   markdown-lint:
     name: Markdown lint
@@ -104,6 +120,8 @@ jobs:
             registry.npmjs.org:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - run: npm install markdownlint-cli2@0.17.2
       - run: npx markdownlint-cli2 "**/*.md"
@@ -120,6 +138,8 @@ jobs:
           disable-sudo: true
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
         with:
@@ -129,3 +149,35 @@ jobs:
             **/*.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  zizmor:
+    name: GitHub Actions security (zizmor)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        with:
+          egress-policy: block
+          disable-sudo: true
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            astral.sh:443
+            release-assets.githubusercontent.com:443
+            raw.githubusercontent.com:443
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.11.11"
+
+      # Pin zizmor itself; bumped via Dependabot's `uv` ecosystem once added
+      # to a [dependency-groups] entry, or manually for now.
+      - run: uvx zizmor==1.24.1 --min-severity=medium .

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ cp -r skills/harden-packages ~/.claude/skills/
 |-----|--------|
 | [Dependabot](docs/dependabot.md) | Cooldown configuration per ecosystem, semver-level delay, known Terraform provider bug |
 | [Harden-Runner](docs/harden-runner.md) | Runtime CI egress control, audit → block mode, per-ecosystem `allowed-endpoints` |
-| [GitHub Actions](docs/github-actions.md) | SHA pinning, least-privilege permissions, expression injection, OIDC, CODEOWNERS |
+| [GitHub Actions](docs/github-actions.md) | SHA pinning, least-privilege permissions, expression injection, OIDC, CODEOWNERS, `persist-credentials: false`, workflow concurrency, zizmor static analysis |
 | [Container Images](docs/docker.md) | Base image digest pinning, official images, distroless, Docker Scout, Cosign, Dependabot |
 
 ### AI assistant tooling

--- a/agents/AGENTS-github-actions.md
+++ b/agents/AGENTS-github-actions.md
@@ -8,6 +8,40 @@ SPDX-License-Identifier: MIT
 
 This file contains mandatory guidelines for working with GitHub Actions workflows in this repository. Follow these rules whenever adding, modifying, or reviewing files under `.github/workflows/`.
 
+## Checkout: disable credential persistence
+
+Every `actions/checkout` invocation must set `persist-credentials: false` unless the job genuinely needs to push back to the repo (release tagging, automated commits). The default leaves `GITHUB_TOKEN` in `.git/config` for the rest of the job, where any subsequent step — including a compromised dependency build — can use it.
+
+```yaml
+- uses: actions/checkout@<sha> # v4
+  with:
+    persist-credentials: false
+```
+
+If a job needs to push, override only in that job and document why in a YAML comment.
+
+## Workflow concurrency
+
+Every workflow must declare a top-level `concurrency:` block. For CI workflows (lint/test/build), cancel superseded runs:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+For release / deploy workflows where in-flight runs should complete, keep the `group:` but set `cancel-in-progress: false`.
+
+## Static analysis: zizmor
+
+Every repository must run [`zizmor`](https://docs.zizmor.sh) against `.github/workflows/` in CI as a required status check. zizmor catches the controls in this file plus many others (template injection, mutable reusable-workflow refs, dangerous triggers, secrets exposed to forks, etc.) and is the canonical static analyser for this domain.
+
+Minimum gate: `--min-severity=medium` on the default persona. Stricter gate (preferred for security-sensitive repos): `--persona=auditor --min-severity=low`.
+
+New or modified workflows must pass `uvx zizmor --persona=auditor .` locally before being committed. New zizmor findings must not be merged — either fix the underlying issue or, if it is a confirmed false positive, suppress it explicitly with a `# zizmor: ignore[<rule>]` comment plus a justification in the PR description.
+
+Do not downgrade the `--min-severity` threshold or remove the zizmor job from CI without explicit human approval.
+
 ## Action Version Pinning
 
 **Always pin actions to their full commit SHA**, not to a version tag. Include the human-readable tag as a comment on the same line:
@@ -121,3 +155,6 @@ The following changes must not be made autonomously and require explicit human a
 - Adding `pull_request_target` triggers
 - Granting any permission beyond `contents: read` at the workflow level
 - Modifying the Dependabot configuration for the `github-actions` ecosystem
+- Setting `persist-credentials: true` (or omitting it, which defaults to `true`) on `actions/checkout`
+- Removing or weakening the workflow-level `concurrency:` block
+- Removing the zizmor job, lowering its `--min-severity`, or suppressing a finding without a documented justification

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -178,6 +178,77 @@ Workflow files define what runs in CI and have access to all repository secrets.
 
 Without CODEOWNERS, a contributor with write access to a branch can add a malicious step to a workflow and merge it without additional review.
 
+## Disable credential persistence in checkouts
+
+By default, `actions/checkout` writes the `GITHUB_TOKEN` into `.git/config` after fetching, so subsequent steps in the same job can `git push` or otherwise use the token. Any compromised dependency build, lint plugin, or post-install script in a later step can then exfiltrate or abuse it. Unless the job genuinely needs to push back to the repo (release tagging, automated commits), set `persist-credentials: false` on every checkout:
+
+```yaml
+# Default — token is left in .git/config for the rest of the job
+- uses: actions/checkout@<sha> # v4
+
+# Safe — token is wiped after the fetch completes
+- uses: actions/checkout@<sha> # v4
+  with:
+    persist-credentials: false
+```
+
+This is one of zizmor's most common findings (`artipacked`).
+
+## Cancel superseded runs (concurrency)
+
+Without a workflow-level `concurrency:` block, rapid pushes to the same PR or branch stack overlapping runs. They burn Actions minutes, can create races between deploy jobs, and amplify the blast radius of a compromised dependency (more concurrent runs = more secret-bearing processes alive at once). Add:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+For release / deploy workflows where in-flight runs should complete, set `cancel-in-progress: false` instead, but always set the `group`.
+
+## Static analysis with zizmor
+
+[`zizmor`](https://docs.zizmor.sh) is a static analyser for GitHub Actions workflows. It catches the issues described above plus dozens more (template injection, unpinned actions, dangerous triggers, missing `permissions:`, mutable reusable-workflow refs, secrets exposed to forks, and so on). Run it locally and in CI:
+
+```bash
+# Local
+uvx zizmor .                              # default persona, medium+ findings
+uvx zizmor --persona=auditor .            # adds informational + low findings
+```
+
+In CI, install via `astral-sh/setup-uv` (already SHA-pinned for the Python jobs) and pin the zizmor version:
+
+```yaml
+  zizmor:
+    name: GitHub Actions security (zizmor)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: step-security/harden-runner@<sha> # v2
+        with:
+          egress-policy: block
+          disable-sudo: true
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            astral.sh:443
+            release-assets.githubusercontent.com:443
+            raw.githubusercontent.com:443
+      - uses: actions/checkout@<sha> # v4
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@<sha> # v8.x
+        with:
+          version: "0.11.11"
+      - run: uvx zizmor==1.24.1 --min-severity=medium .
+```
+
+Move the zizmor pin into `pyproject.toml [dependency-groups].dev` if you want Dependabot's `uv` ecosystem to keep it current automatically. `--min-severity=medium` mirrors the default persona's threshold; raise to `--persona=auditor --min-severity=low` for a stricter gate.
+
 ## Dependabot for action updates
 
 Configure Dependabot to keep action SHAs and version comments current:
@@ -207,6 +278,9 @@ Dependabot understands SHA-pinned actions and will propose updates with both the
 | Least-privilege token | `permissions: contents: read` at workflow level |
 | Runtime egress control | `step-security/harden-runner` on every job |
 | Pin tool installs | `pip install tool==x.y.z`, not bare `pip install tool` |
+| Disable credential persistence | `with: persist-credentials: false` on every `actions/checkout` |
+| Cancel superseded runs | `concurrency: { group: ${{ github.workflow }}-${{ github.ref }}, cancel-in-progress: true }` |
+| Static analysis | `zizmor` job in CI; SHA-pinned, `--min-severity=medium` |
 | Avoid `pull_request_target` | Use `pull_request` unless write access is explicitly needed |
 | Prevent expression injection | Pass untrusted values via `env:`, not `${{ }}` in `run:` |
 | OIDC for cloud auth | `id-token: write` + federated identity; no long-lived keys |

--- a/skills/harden-packages/SKILL.md
+++ b/skills/harden-packages/SKILL.md
@@ -5,10 +5,12 @@ description: >
   Use this skill whenever the user wants to: audit dependency security, check package
   manager hardening, apply supply chain security best practices, set up Dependabot
   cooldowns, configure Harden-Runner in GitHub Actions, pin dependency versions, add
-  lockfiles, configure minimum release age, check for unpinned dependencies, or
+  lockfiles, configure minimum release age, check for unpinned dependencies, run
+  zizmor static analysis on GitHub Actions workflows, or
   review CI/CD pipeline security. Also trigger when the user says things like "harden
   my repo", "check my dependencies", "is my package config secure?", "set up supply
-  chain security", "add Dependabot", or "are my packages safe?". Works across Node.js
+  chain security", "add Dependabot", "run zizmor", or "are my packages safe?". Works
+  across Node.js
   (npm/pnpm/yarn/bun), Python (pip/uv), Go, Rust/Cargo, PHP/Composer, Ruby/Bundler,
   JVM (Maven, Gradle — Java and Kotlin), and Terraform/OpenTofu repos
 ---
@@ -113,13 +115,16 @@ Example report structure:
 ### GitHub Actions
 ⚠️ ci.yml: harden-runner present but egress-policy is "audit", not "block"
 ❌ release.yml: harden-runner not present
+❌ No zizmor static analysis configured
+⚠️ actions/checkout in ci.yml does not set persist-credentials: false (zizmor: artipacked × 3)
 
 ### Priority fixes
 1. Add harden-runner to release.yml — release workflows are high-value targets
-2. Set egress-policy: block in ci.yml once allowlist is confirmed
-3. Add require-hashes = true under [tool.uv.pip] (defensive, for ad-hoc `uv pip install`)
-4. Add pip entry to dependabot.yml
-5. Set trustPolicy: no-downgrade in pnpm-workspace.yaml
+2. Add a zizmor job to CI; pin the version (`uvx zizmor==X.Y.Z`) and resolve current findings
+3. Set egress-policy: block in ci.yml once allowlist is confirmed
+4. Add require-hashes = true under [tool.uv.pip] (defensive, for ad-hoc `uv pip install`)
+5. Add pip entry to dependabot.yml
+6. Set trustPolicy: no-downgrade in pnpm-workspace.yaml
 ```
 
 ## Step 4: Offer to fix
@@ -505,6 +510,7 @@ Append the ecosystem-specific endpoints:
 - **Go stdlib CVEs**: standard library vulnerabilities cannot be fixed by bumping a `require` entry — they require upgrading the `go` directive in `go.mod` to the patched Go release. When govulncheck reports stdlib findings, check the "Fixed in" version and update the `go` directive accordingly.
 - **Go `go` directive format**: use the full patch version (`go 1.25.9`), not the bare minor (`go 1.25`) or base patch (`go 1.25.0`). `go mod tidy` preserves fully-specified patch versions but normalises `go 1.25` → `go 1.25.0`. govulncheck reads the `go` directive as the stdlib CVE baseline — `go 1.25.0` will surface all CVEs fixed in 1.25.1 through the latest patch. Do **not** split a patch-versioned `go` directive into `go 1.25` + `toolchain go1.25.9` on the assumption that the toolchain directive covers CVE exposure — it does not; only the `go` directive does.
 - **Reusable workflow pinning**: job-level `uses:` entries that delegate to a reusable workflow (e.g., SLSA generators, shared org workflows) are mutable refs and must be SHA-pinned, just like step-level actions. They cannot receive harden-runner steps, so flag them separately.
+- **zizmor in CI**: if the user wants to harden a GitHub Actions setup, recommend adding a `zizmor` job alongside Harden-Runner. They are complementary — Harden-Runner is runtime egress control, zizmor is static analysis of the workflow file itself. Pin the zizmor version (`uvx zizmor==X.Y.Z`) and run at `--min-severity=medium` (default persona) or `--persona=auditor --min-severity=low` (stricter).
 
 ---
 
@@ -614,3 +620,19 @@ Use this section only if `audit.py` cannot be run. It replicates what the script
 - Is `step-security/harden-runner` (SHA-pinned, e.g. `@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2`) the first step in every job that installs dependencies? Flag any `@v2` / `@v3` / `@main` references — actions must be SHA-pinned to a 40-char commit, with a `# vX.Y.Z` trailing comment.
 - Is `egress-policy` set to `block` (not `audit`)? Is `disable-sudo: true` set?
 - Are job-level `uses:` entries (reusable workflows) SHA-pinned? These are mutable refs just like step-level `uses:` but **cannot receive harden-runner steps** — the entire job is delegated to the reusable workflow. Flag unpinned reusable workflow refs separately from the harden-runner audit.
+
+### Workflow static analysis (zizmor)
+
+[`zizmor`](https://docs.zizmor.sh) is the canonical static analyser for GitHub Actions workflows. It catches issues the file-based checks above can't reach — template injection, missing `persist-credentials: false`, missing workflow `concurrency:`, dangerous triggers (`pull_request_target` with checkout-of-head), secrets exposed to forks, mutable reusable-workflow refs, etc.
+
+- Is there a `zizmor` job in CI? Flag as ❌ if missing.
+- Is the zizmor version pinned (e.g. `uvx zizmor==1.24.1`)? Flag bare `uvx zizmor` as ⚠️.
+- Is `--min-severity` set to at least `medium` (default) or `low` (preferred, with `--persona=auditor`)?
+- When recommending or adding zizmor, run it locally first: `uvx zizmor --persona=auditor .`. Report each finding and offer to fix; do not auto-suppress findings.
+- Common findings to know:
+  - **`artipacked`** (medium): `actions/checkout` missing `persist-credentials: false`. Fix on every checkout unless the job pushes to git.
+  - **`template-injection`** (high/medium): `${{ ... }}` interpolated into a `run:` block. Fix by passing the value through `env:` and quoting `"$VAR"` in the shell.
+  - **`concurrency-limits`** (low): no workflow-level `concurrency:` block. Add one keyed on `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true` for CI; `false` for release/deploy workflows.
+  - **`dangerous-triggers`** (high): `pull_request_target` combined with a checkout of `github.event.pull_request.head.ref`. Requires immediate human review.
+  - **`unpinned-uses`** (high): action referenced by tag (`@v4`) instead of SHA. Already covered by the harden-runner / SHA-pinning checks above, but zizmor will surface it again.
+  - **`excessive-permissions`** (medium): workflow or job missing `permissions:` declaration, or granting more than `contents: read` without justification.


### PR DESCRIPTION
## Summary

Ran [zizmor](https://docs.zizmor.sh) 1.24.1 (auditor persona) against this repo, got 7 findings, fixed all of them, and wired zizmor into CI as a required status check so future workflow changes get the same scrutiny. Also propagated zizmor into the skill / docs / AGENTS recommendations.

## Workflow fixes (`.github/workflows/ci.yml`)

| Finding | Fix |
|---|---|
| `artipacked` × 5 (medium) | Added `persist-credentials: false` to all 5 `actions/checkout` calls. The default leaves `GITHUB_TOKEN` in `.git/config` for the rest of the job. |
| `concurrency-limits` (low) | Added workflow-level `concurrency:` block keyed on `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`. |
| `template-injection` (low) | Replaced `uv sync ... --python ${{ matrix.python-version }}` with an `env:` pass-through. `matrix.python-version` is not attacker-controllable, but the env form is the canonical safe construct and zizmor will keep flagging the interpolation pattern. |

After fixes: `zizmor --persona=auditor .` → `No findings to report. Good job!`

## New CI job

Added a **`GitHub Actions security (zizmor)`** job that runs `uvx zizmor==1.24.1 --min-severity=medium .` on every push/PR. It reuses the SHA-pinned `astral-sh/setup-uv` we already trust for the Python jobs, with the same Harden-Runner allowlist (now battle-tested across 4 prior PRs).

Branch protection has been updated to make this job a required status check on `main`.

## Recommendation propagation

- **`skills/harden-packages/SKILL.md`**: zizmor added to the skill description + trigger phrases (`run zizmor`). New "Workflow static analysis (zizmor)" subsection under Harden-Runner enumerating the six most common findings (`artipacked`, `template-injection`, `concurrency-limits`, `dangerous-triggers`, `unpinned-uses`, `excessive-permissions`) with remediations. Sample audit report and priority-fix list updated to surface zizmor gaps.
- **`docs/github-actions.md`**: new sections on "Disable credential persistence in checkouts", "Cancel superseded runs (concurrency)", and "Static analysis with zizmor" (with a SHA-pinned CI example). Summary checklist extended with three new rows.
- **`agents/AGENTS-github-actions.md`**: new required sections for checkout `persist-credentials`, workflow `concurrency`, and zizmor (with `--min-severity` gates and human-review rules for suppressions / threshold changes).
- **`README.md`**: ecosystem-doc summary row extended.

## Verification

- `zizmor .` and `zizmor --persona=auditor .` — clean
- `uv run pytest tests/ -q` — 202/202
- `reuse lint` — 50/50 files compliant
- `markdownlint-cli2 "**/*.md"` — 28 files, 0 errors

## Notes

The next zizmor bump can be handled by Dependabot's `uv` ecosystem if we move the version pin into `pyproject.toml [dependency-groups]`. Left it inline (`uvx zizmor==1.24.1`) for now — happy to switch if you'd prefer.

🤖 Generated with [pi](https://github.com/badlogic/lemmy/tree/main/apps/pi)
