### PR TITLE
ci+docs: CI hardening pack (dependency-review, scorecard, runner pinning, SECURITY.md)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   reuse:
     name: REUSE compliance
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
         with:
@@ -41,7 +41,7 @@ jobs:
 
   python-lint:
     name: Python lint (ruff)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
         with:
@@ -71,7 +71,7 @@ jobs:
 
   python-test:
     name: Python tests (py${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ["3.10", "3.12"]
@@ -107,7 +107,7 @@ jobs:
 
   markdown-lint:
     name: Markdown lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
         with:
@@ -128,7 +128,7 @@ jobs:
 
   link-check:
     name: Link check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       # Audit mode: this job fetches arbitrary external URLs from the markdown
       # files and cannot use a fixed allowlist. Review audit logs periodically.
@@ -150,9 +150,39 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  dependency-review:
+    name: Dependency review
+    # PR-only: compares head against base and blocks new vulnerable / disallowed-license deps.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write  # post the review summary as a PR comment
+    steps:
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        with:
+          egress-policy: block
+          disable-sudo: true
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/dependency-review-action@05fe4576374b728f0c523d6a13d64c25081e0803 # v4.8.3
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure
+          # License denylist: copyleft licenses that would taint this MIT repo.
+          # Adjust per project; an allowlist is stricter but harder to maintain.
+          deny-licenses: GPL-2.0, GPL-3.0, AGPL-1.0, AGPL-3.0
+
   zizmor:
     name: GitHub Actions security (zizmor)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+#
+# SPDX-License-Identifier: MIT
+
+# OpenSSF Scorecard — automated supply-chain posture scoring.
+# Runs weekly + on pushes to main; uploads SARIF to the Security tab and
+# publishes results so the README badge resolves.
+#
+# Docs: https://github.com/ossf/scorecard-action
+# Checks: https://github.com/ossf/scorecard/blob/main/docs/checks.md
+
+name: Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "37 5 * * 1"  # weekly, Monday 05:37 UTC
+  push:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write  # upload SARIF results to the Security tab
+      id-token: write         # publish results to OpenSSF (resolves README badge)
+      contents: read          # checkout
+      actions: read           # scorecard reads workflow files/runs to score token-permissions + pinned-deps
+    steps:
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        with:
+          egress-policy: audit  # scorecard contacts many external endpoints; audit is the documented mode
+          disable-sudo: true
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish results to OpenSSF so the README badge works.
+          publish_results: true
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - uses: github/codeql-action/upload-sarif@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3.35.4
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ SPDX-License-Identifier: MIT
 
 # Package Manager Security Hardening
 
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/jordanconway/package-manager-hardening/badge)](https://scorecard.dev/viewer/?uri=github.com/jordanconway/package-manager-hardening)
+[![REUSE status](https://api.reuse.software/badge/github.com/jordanconway/package-manager-hardening)](https://api.reuse.software/info/github.com/jordanconway/package-manager-hardening)
+
 A reference for hardening software supply chains across npm, pnpm, Yarn, Bun, pip, uv, Go modules, Cargo, Maven, Gradle, Terraform, and OpenTofu.
 
 Supply chain attacks typically succeed through one of a small number of vectors: a loose version constraint allows a newly published malicious version to be silently pulled in; a missing or unenforced lockfile lets an attacker's package substitute for a legitimate one; a compromised maintainer account publishes a backdoored patch release that lands in CI within minutes of publication; or a package's postinstall script runs arbitrary code during a routine `npm install`. This repository addresses all of these through a layered set of controls applied consistently across ecosystems.
@@ -77,7 +80,7 @@ cp -r skills/harden-packages ~/.claude/skills/
 |-----|--------|
 | [Dependabot](docs/dependabot.md) | Cooldown configuration per ecosystem, semver-level delay, known Terraform provider bug |
 | [Harden-Runner](docs/harden-runner.md) | Runtime CI egress control, audit → block mode, per-ecosystem `allowed-endpoints` |
-| [GitHub Actions](docs/github-actions.md) | SHA pinning, least-privilege permissions, expression injection, OIDC, CODEOWNERS, `persist-credentials: false`, workflow concurrency, zizmor static analysis |
+| [GitHub Actions](docs/github-actions.md) | SHA pinning, runner image pinning, least-privilege permissions, expression injection, OIDC, CODEOWNERS, `persist-credentials: false`, workflow concurrency, zizmor static analysis, dependency-review on PRs, OpenSSF Scorecard, `SECURITY.md` + private vulnerability reporting |
 | [Container Images](docs/docker.md) | Base image digest pinning, official images, distroless, Docker Scout, Cosign, Dependabot |
 
 ### AI assistant tooling

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+<!--
+SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+SPDX-License-Identifier: MIT
+-->
+
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in this repository, please report it through GitHub's [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) feature:
+
+> [Report a vulnerability](https://github.com/jordanconway/package-manager-hardening/security/advisories/new)
+
+This creates a private security advisory visible only to repository maintainers and to you, with a built-in workflow for coordinated disclosure, CVE assignment, and patch publication.
+
+**Please do not report security vulnerabilities through public GitHub issues, pull requests, or discussions.**
+
+## What to include
+
+- A description of the issue and its security impact
+- Steps to reproduce, ideally with a minimal example
+- Affected versions / commit SHAs
+- Any suggested mitigation or patch
+- Whether you would like to be credited in the advisory
+
+## Response expectations
+
+This is a documentation and tooling repository — it does not run as a service and has no production deployment. The most likely classes of issue are:
+
+- A flaw in the audit script (`skills/harden-packages/audit.py`) that causes it to under-report a real misconfiguration, falsely report a safe one, or be exploitable when run against an untrusted repo
+- Bad advice in the documentation (e.g. an `allowed-endpoints` list that allows exfiltration, a recommended action SHA that turns out to be malicious)
+- A vulnerability in this repo's own CI (workflow injection, secret exposure, etc.)
+
+Maintainers will acknowledge reports within **7 days** and aim to publish a fix or mitigation within **30 days** of confirmation. Critical issues affecting downstream consumers (e.g. malicious advice that has already been merged) will be triaged faster.
+
+## Scope
+
+In scope:
+
+- This repository's source, documentation, and CI workflows
+- The `harden-packages` skill files in `skills/harden-packages/`
+- The `AGENTS-*.md` files in `agents/`
+
+Out of scope:
+
+- Vulnerabilities in third-party tools the docs reference (Dependabot, Harden-Runner, zizmor, uv, etc.) — please report those directly to the upstream projects
+- Issues in user repositories that adopt these recommendations

--- a/agents/AGENTS-github-actions.md
+++ b/agents/AGENTS-github-actions.md
@@ -42,6 +42,32 @@ New or modified workflows must pass `uvx zizmor --persona=auditor .` locally bef
 
 Do not downgrade the `--min-severity` threshold or remove the zizmor job from CI without explicit human approval.
 
+## Pin runner images
+
+`runs-on: ubuntu-latest` is mutable and changes underneath you. Always pin to a specific image (`ubuntu-24.04`, `ubuntu-22.04`, `windows-2022`, `macos-14`). Bump explicitly when you've validated the new image. Dependabot does not propose runner-image bumps; track these manually.
+
+## Block vulnerable / disallowed dependencies on PRs
+
+Every repository must run `actions/dependency-review-action` as a PR-only required status check. It compares head against base and fails on:
+
+- Vulnerabilities at or above `fail-on-severity: high` (or stricter)
+- Licenses on the `deny-licenses` list (project-specific)
+- Packages on the `deny-packages` list, if any
+
+Do not lower `fail-on-severity` below `high` without explicit human approval. Do not delete the job or remove its required-check status without explicit human approval.
+
+## OpenSSF Scorecard
+
+Every repository must publish an OpenSSF Scorecard score via `ossf/scorecard-action`, run on a weekly schedule and on push to `main`. SARIF results upload to the Security tab; results publish to the OpenSSF API so the README badge resolves.
+
+The Scorecard workflow uses `egress-policy: audit`, not `block` — the analyser legitimately contacts dozens of ecosystem endpoints. Do not change to `block`.
+
+A dropping Scorecard score is a regression that must be triaged like any other CI failure. Common causes: a new unpinned action, a removed branch protection rule, a permission grant added without justification.
+
+## Vulnerability disclosure: SECURITY.md
+
+Every repository must have a root `SECURITY.md` linking to GitHub's private vulnerability reporting (`https://github.com/<owner>/<repo>/security/advisories/new`), with explicit "do not file public issues" wording, expected response SLOs, and scope. Private vulnerability reporting must be enabled in repo Settings → Code security → "Privately report a vulnerability".
+
 ## Action Version Pinning
 
 **Always pin actions to their full commit SHA**, not to a version tag. Include the human-readable tag as a comment on the same line:
@@ -158,3 +184,7 @@ The following changes must not be made autonomously and require explicit human a
 - Setting `persist-credentials: true` (or omitting it, which defaults to `true`) on `actions/checkout`
 - Removing or weakening the workflow-level `concurrency:` block
 - Removing the zizmor job, lowering its `--min-severity`, or suppressing a finding without a documented justification
+- Removing the dependency-review job, lowering its `fail-on-severity`, or removing it from required status checks
+- Removing the Scorecard workflow, or changing its `egress-policy` away from `audit`
+- Bumping a runner image (`ubuntu-24.04` → `ubuntu-26.04`, etc.) without confirming the matrix still passes
+- Removing or weakening `SECURITY.md` or disabling private vulnerability reporting

--- a/agents/AGENTS-github-actions.md
+++ b/agents/AGENTS-github-actions.md
@@ -56,6 +56,8 @@ Every repository must run `actions/dependency-review-action` as a PR-only requir
 
 Do not lower `fail-on-severity` below `high` without explicit human approval. Do not delete the job or remove its required-check status without explicit human approval.
 
+The action requires Dependabot security updates to be enabled on the repo (Settings → Code security, or `gh api -X PATCH repos/<owner>/<repo> -f 'security_and_analysis[dependabot_security_updates][status]=enabled'`). Without it, every run fails with `Dependency review is not supported on this repository`. When adding the job to a repo that doesn't already have it enabled, enable the setting in the same change.
+
 ## OpenSSF Scorecard
 
 Every repository must publish an OpenSSF Scorecard score via `ossf/scorecard-action`, run on a weekly schedule and on push to `main`. SARIF results upload to the Security tab; results publish to the OpenSSF API so the README badge resolves.

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -259,6 +259,15 @@ It's PR-only, free, and requires no infrastructure. It also writes a summary com
 
 Make the job a required status check on `main` so it cannot be merged around. Tune `fail-on-severity` (`critical | high | moderate | low`) to your project's risk tolerance.
 
+**Prerequisite**: `dependency-review-action` requires Dependabot security updates to be enabled on the repo (not just the always-on dependency graph). Without it, every run fails with `Dependency review is not supported on this repository. Please ensure that Dependency graph is enabled`. Enable via Settings → Code security → "Dependabot security updates", or:
+
+```bash
+gh api -X PATCH repos/<owner>/<repo> \
+  -f 'security_and_analysis[dependabot_security_updates][status]=enabled'
+```
+
+This is free for public repos and included with GitHub Advanced Security for private repos.
+
 ## OpenSSF Scorecard
 
 [OpenSSF Scorecard](https://github.com/ossf/scorecard) automatically scores a repository against ~20 supply-chain best practices (branch protection, signed releases, pinned dependencies, token permissions, fuzzing, vulnerability response, etc.) and uploads results as SARIF to the Security tab. The score is the de-facto external benchmark and a Scorecard badge is now common on hardened OSS projects.

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -206,6 +206,126 @@ concurrency:
 
 For release / deploy workflows where in-flight runs should complete, set `cancel-in-progress: false` instead, but always set the `group`.
 
+## Pin the runner image
+
+`runs-on: ubuntu-latest` is a moving target. GitHub rolls it forward when a new Ubuntu LTS reaches general availability, and has historically changed pre-installed tool versions silently mid-lifecycle. Builds that worked yesterday can fail or, worse, succeed against a different toolchain than you expected. Pin to a specific runner image:
+
+```yaml
+# Bad
+runs-on: ubuntu-latest
+
+# Good
+runs-on: ubuntu-24.04
+```
+
+The same applies to `windows-latest` and `macos-latest`. Bump explicitly when a new image is GA and you've validated your matrix against it. Dependabot does not propose runner-image bumps, so add a calendar reminder or track it in your dependency-review process.
+
+## Block vulnerable / disallowed dependencies on PRs
+
+[`actions/dependency-review-action`](https://github.com/actions/dependency-review-action) compares the PR head against the base branch and fails the check if the diff introduces:
+
+- A dependency with a known vulnerability at or above the configured severity
+- A package on a denylist (e.g. known-malicious or internal-fork-required packages)
+- A license on a denylist (e.g. copyleft licenses incompatible with your project)
+
+It's PR-only, free, and requires no infrastructure. It also writes a summary comment on the PR describing what changed.
+
+```yaml
+  dependency-review:
+    name: Dependency review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write  # for the summary comment
+    steps:
+      - uses: step-security/harden-runner@<sha> # v2
+        with:
+          egress-policy: block
+          disable-sudo: true
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+      - uses: actions/checkout@<sha> # v4
+        with:
+          persist-credentials: false
+      - uses: actions/dependency-review-action@<sha> # v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure
+          deny-licenses: GPL-2.0, GPL-3.0, AGPL-1.0, AGPL-3.0
+```
+
+Make the job a required status check on `main` so it cannot be merged around. Tune `fail-on-severity` (`critical | high | moderate | low`) to your project's risk tolerance.
+
+## OpenSSF Scorecard
+
+[OpenSSF Scorecard](https://github.com/ossf/scorecard) automatically scores a repository against ~20 supply-chain best practices (branch protection, signed releases, pinned dependencies, token permissions, fuzzing, vulnerability response, etc.) and uploads results as SARIF to the Security tab. The score is the de-facto external benchmark and a Scorecard badge is now common on hardened OSS projects.
+
+Add it as a separate workflow file (not an additional job in `ci.yml`), so the schedule + permissions stay isolated:
+
+```yaml
+# .github/workflows/scorecard.yml
+name: Scorecard
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "37 5 * * 1"
+  push:
+    branches: [main]
+permissions: {}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  analysis:
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write  # SARIF upload
+      id-token: write         # publish results to OpenSSF (badge)
+      contents: read
+      actions: read
+    steps:
+      - uses: step-security/harden-runner@<sha> # v2
+        with:
+          egress-policy: audit  # scorecard hits many endpoints; block is impractical
+          disable-sudo: true
+      - uses: actions/checkout@<sha> # v4
+        with:
+          persist-credentials: false
+      - uses: ossf/scorecard-action@<sha> # v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - uses: github/codeql-action/upload-sarif@<sha> # v3
+        with:
+          sarif_file: results.sarif
+```
+
+Add the badge to your README so the score is publicly visible:
+
+```markdown
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/<owner>/<repo>/badge)](https://scorecard.dev/viewer/?uri=github.com/<owner>/<repo>)
+```
+
+Scorecard's `egress-policy` must be `audit`, not `block` — the analyser legitimately contacts dozens of endpoints (deps.dev, OSV, npm, PyPI, etc.) to score your project against the ecosystem.
+
+## SECURITY.md and private vulnerability reporting
+
+Every repository should have a `SECURITY.md` at the root, and should enable GitHub's [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) under Settings → Code security. Together they give security researchers a clearly documented, non-public channel to disclose vulnerabilities, with a built-in workflow for coordinated disclosure, CVE assignment, and patch publication.
+
+Minimum `SECURITY.md` content:
+
+- A link to the "Report a vulnerability" form at `https://github.com/<owner>/<repo>/security/advisories/new`
+- An explicit "do not file public issues" line
+- What to include in a report (repro, affected versions, impact)
+- Response-time expectations (acknowledgement and patch SLOs)
+- Scope (what is and isn't covered)
+
+Without this, researchers either file public issues (worst case) or never report at all.
+
 ## Static analysis with zizmor
 
 [`zizmor`](https://docs.zizmor.sh) is a static analyser for GitHub Actions workflows. It catches the issues described above plus dozens more (template injection, unpinned actions, dangerous triggers, missing `permissions:`, mutable reusable-workflow refs, secrets exposed to forks, and so on). Run it locally and in CI:
@@ -221,7 +341,7 @@ In CI, install via `astral-sh/setup-uv` (already SHA-pinned for the Python jobs)
 ```yaml
   zizmor:
     name: GitHub Actions security (zizmor)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:
@@ -275,11 +395,15 @@ Dependabot understands SHA-pinned actions and will propose updates with both the
 | Control | How |
 |---|---|
 | Pin actions to SHAs | `uses: owner/action@<full-sha> # vX` |
+| Pin runner images | `runs-on: ubuntu-24.04`, never `ubuntu-latest` |
 | Least-privilege token | `permissions: contents: read` at workflow level |
 | Runtime egress control | `step-security/harden-runner` on every job |
 | Pin tool installs | `pip install tool==x.y.z`, not bare `pip install tool` |
 | Disable credential persistence | `with: persist-credentials: false` on every `actions/checkout` |
 | Cancel superseded runs | `concurrency: { group: ${{ github.workflow }}-${{ github.ref }}, cancel-in-progress: true }` |
+| Block vulnerable PR deps | `actions/dependency-review-action` as required check on PRs |
+| External posture scoring | `ossf/scorecard-action` weekly + on push to main, with badge |
+| Vulnerability disclosure | `SECURITY.md` + GitHub private vulnerability reporting enabled |
 | Static analysis | `zizmor` job in CI; SHA-pinned, `--min-severity=medium` |
 | Avoid `pull_request_target` | Use `pull_request` unless write access is explicitly needed |
 | Prevent expression injection | Pass untrusted values via `env:`, not `${{ }}` in `run:` |

--- a/skills/harden-packages/SKILL.md
+++ b/skills/harden-packages/SKILL.md
@@ -660,6 +660,14 @@ Use this section only if `audit.py` cannot be run. It replicates what the script
 - Is there a `deny-licenses` list appropriate to the project's own license? At minimum, MIT/Apache projects should deny GPL/AGPL.
 - Is `comment-summary-in-pr: on-failure` set so contributors see why the check failed?
 - Is the job a required status check on `main`? If not, the gate can be merged around.
+- **Gotcha**: the action requires Dependabot security updates to be enabled on the repo (not just the always-on dependency graph). Without it, the job fails with `Dependency review is not supported on this repository. Please ensure that Dependency graph is enabled`. Enable it with:
+
+  ```bash
+  gh api -X PATCH repos/<owner>/<repo> \
+    -f 'security_and_analysis[dependabot_security_updates][status]=enabled'
+  ```
+
+  Verify with `gh api repos/<owner>/<repo> --jq '.security_and_analysis.dependabot_security_updates.status'` — should return `enabled`. This is free for public repos and included with GitHub Advanced Security for private repos. Add this to the fix plan whenever you recommend `dependency-review-action`, and re-run any failed job after flipping the setting.
 
 ### OpenSSF Scorecard
 

--- a/skills/harden-packages/SKILL.md
+++ b/skills/harden-packages/SKILL.md
@@ -117,14 +117,22 @@ Example report structure:
 ❌ release.yml: harden-runner not present
 ❌ No zizmor static analysis configured
 ⚠️ actions/checkout in ci.yml does not set persist-credentials: false (zizmor: artipacked × 3)
+⚠️ ci.yml uses `runs-on: ubuntu-latest` (4 jobs) — should pin to `ubuntu-24.04`
+❌ No `actions/dependency-review-action` job (PRs can introduce vulnerable deps unchecked)
+❌ No OpenSSF Scorecard workflow
+❌ No `SECURITY.md` and private vulnerability reporting is disabled
 
 ### Priority fixes
 1. Add harden-runner to release.yml — release workflows are high-value targets
 2. Add a zizmor job to CI; pin the version (`uvx zizmor==X.Y.Z`) and resolve current findings
-3. Set egress-policy: block in ci.yml once allowlist is confirmed
-4. Add require-hashes = true under [tool.uv.pip] (defensive, for ad-hoc `uv pip install`)
-5. Add pip entry to dependabot.yml
-6. Set trustPolicy: no-downgrade in pnpm-workspace.yaml
+3. Add `actions/dependency-review-action` as a PR-only required check (fail-on-severity: high, license denylist)
+4. Add `ossf/scorecard-action` workflow (weekly + push to main) with SARIF upload + README badge
+5. Add `SECURITY.md` linking to private vulnerability reporting; enable PVR in repo Settings
+6. Pin runner images: `ubuntu-latest` → `ubuntu-24.04` across all jobs
+7. Set egress-policy: block in ci.yml once allowlist is confirmed
+8. Add require-hashes = true under [tool.uv.pip] (defensive, for ad-hoc `uv pip install`)
+9. Add pip entry to dependabot.yml
+10. Set trustPolicy: no-downgrade in pnpm-workspace.yaml
 ```
 
 ## Step 4: Offer to fix
@@ -511,6 +519,8 @@ Append the ecosystem-specific endpoints:
 - **Go `go` directive format**: use the full patch version (`go 1.25.9`), not the bare minor (`go 1.25`) or base patch (`go 1.25.0`). `go mod tidy` preserves fully-specified patch versions but normalises `go 1.25` → `go 1.25.0`. govulncheck reads the `go` directive as the stdlib CVE baseline — `go 1.25.0` will surface all CVEs fixed in 1.25.1 through the latest patch. Do **not** split a patch-versioned `go` directive into `go 1.25` + `toolchain go1.25.9` on the assumption that the toolchain directive covers CVE exposure — it does not; only the `go` directive does.
 - **Reusable workflow pinning**: job-level `uses:` entries that delegate to a reusable workflow (e.g., SLSA generators, shared org workflows) are mutable refs and must be SHA-pinned, just like step-level actions. They cannot receive harden-runner steps, so flag them separately.
 - **zizmor in CI**: if the user wants to harden a GitHub Actions setup, recommend adding a `zizmor` job alongside Harden-Runner. They are complementary — Harden-Runner is runtime egress control, zizmor is static analysis of the workflow file itself. Pin the zizmor version (`uvx zizmor==X.Y.Z`) and run at `--min-severity=medium` (default persona) or `--persona=auditor --min-severity=low` (stricter).
+- **dependency-review + Scorecard + SECURITY.md are all zero-infra GitHub-native controls**: when recommending GitHub Actions hardening, offer all three together as a single "CI hardening pack". They cost nothing, require no external accounts or self-hosting, and produce externally visible posture signal (Scorecard badge) plus a vulnerability-disclosure path (`SECURITY.md` + PVR).
+- **Branch protection**: every new required-check job (zizmor, dependency-review, Scorecard) must be added to the repo's required status checks for the default branch, otherwise it can be merged around. Use `gh api -X PUT repos/<owner>/<repo>/branches/<branch>/protection` and update `required_status_checks.contexts`.
 
 ---
 
@@ -636,3 +646,34 @@ Use this section only if `audit.py` cannot be run. It replicates what the script
   - **`dangerous-triggers`** (high): `pull_request_target` combined with a checkout of `github.event.pull_request.head.ref`. Requires immediate human review.
   - **`unpinned-uses`** (high): action referenced by tag (`@v4`) instead of SHA. Already covered by the harden-runner / SHA-pinning checks above, but zizmor will surface it again.
   - **`excessive-permissions`** (medium): workflow or job missing `permissions:` declaration, or granting more than `contents: read` without justification.
+  - **`undocumented-permissions`** (auditor low): `permissions:` block missing inline comments justifying each grant. Fix with trailing `# why this is needed` comments on each line.
+
+### Runner image pinning
+
+- Are all `runs-on:` values pinned to a specific image (`ubuntu-24.04`, `ubuntu-22.04`, `windows-2022`, `macos-14`)? Flag every `ubuntu-latest` / `windows-latest` / `macos-latest` as ⚠️. GitHub rolls these forward and has historically changed pre-installed tools mid-lifecycle.
+- Note that Dependabot does not propose runner-image bumps. Recommend adding a calendar reminder or tracking via a long-lived issue when a new LTS is GA.
+
+### Dependency review on PRs
+
+- Is there an `actions/dependency-review-action` job, gated on `if: github.event_name == 'pull_request'`? Flag absence as ❌.
+- Is `fail-on-severity` at least `high`? `moderate` or `low` is preferred for security-sensitive repos.
+- Is there a `deny-licenses` list appropriate to the project's own license? At minimum, MIT/Apache projects should deny GPL/AGPL.
+- Is `comment-summary-in-pr: on-failure` set so contributors see why the check failed?
+- Is the job a required status check on `main`? If not, the gate can be merged around.
+
+### OpenSSF Scorecard
+
+- Is there a `.github/workflows/scorecard.yml` running `ossf/scorecard-action` on a weekly schedule + push to `main`? Flag absence as ❌.
+- Are SARIF results uploaded via `github/codeql-action/upload-sarif` so they appear in the Security tab?
+- Is `publish_results: true` set so the README badge resolves?
+- Is the workflow's `egress-policy` set to `audit` (not `block`)? Scorecard legitimately contacts deps.dev, OSV, npm, PyPI, etc. and cannot run under a fixed allowlist. Flag `block` here as ⚠️.
+- Is the Scorecard badge in the README so the score is publicly visible?
+- Note that a *dropping* Scorecard score is a regression to triage — not just a green/red flag at a point in time.
+
+### SECURITY.md and private vulnerability reporting
+
+- Is there a `SECURITY.md` at the repo root? Flag absence as ❌.
+- Does it link to `https://github.com/<owner>/<repo>/security/advisories/new`?
+- Does it include explicit "do not file public issues" wording?
+- Does it state response-time expectations (acknowledgement + patch SLOs)?
+- Is GitHub's private vulnerability reporting enabled? Check via `gh api repos/<owner>/<repo>/private-vulnerability-reporting --jq .enabled`. Flag `false` as ❌. Enable with `gh api -X PUT repos/<owner>/<repo>/private-vulnerability-reporting`.


### PR DESCRIPTION
## Summary

PR A from the supply-chain hardening roadmap. Adds four zero-infra, GitHub-native controls — `actions/dependency-review-action`, OpenSSF Scorecard, runner image pinning, and `SECURITY.md` + private vulnerability reporting — and propagates each into the skill, docs, and AGENTS files so downstream users adopt them too.

## Controls added

| Control | Where | What it catches |
|---|---|---|
| **Dependency review** | New job in `ci.yml`, PR-only, required check | Blocks PRs that introduce vulnerable deps (`fail-on-severity: high`) or disallowed licenses (GPL/AGPL denylist). Posts summary comment on failure. |
| **OpenSSF Scorecard** | New `.github/workflows/scorecard.yml`, weekly + push-to-main | Externally-visible posture score. SARIF → Security tab. Badge on README. |
| **Runner image pinning** | All `runs-on: ubuntu-latest` → `ubuntu-24.04` | Eliminates silent toolchain drift when GitHub rolls `*-latest` forward. |
| **`SECURITY.md` + PVR** | New `SECURITY.md`, PVR enabled on repo | Documented coordinated-disclosure channel. No public issues for vulns. |

All new actions SHA-pinned with `# vX.Y.Z` comments. Every new permission grant has an inline justification comment (zizmor: `undocumented-permissions`). Scorecard runs `egress-policy: audit` (it legitimately contacts dozens of ecosystem endpoints — `block` is impractical and documented as such).

Scorecard is intentionally **not** added to required status checks: it doesn't run on PRs, so making it required would block every merge. It runs on push-to-`main` + schedule and surfaces via the Security tab and the README badge. **Dependency review** is added as a required check on `main` (already pushed via `gh api`).

## Recommendation propagation

- **`skills/harden-packages/SKILL.md`** — four new audit checklist sections (runner image pinning, dependency review, Scorecard, `SECURITY.md`/PVR). One new zizmor finding documented (`undocumented-permissions`). Sample audit report and priority-fix list extended. New "Important notes" guidance: recommend the three new controls together as a "CI hardening pack", and always update `required_status_checks.contexts` alongside any new required-check job.
- **`docs/github-actions.md`** — four new sections with copy-paste-ready YAML (Harden-Runner allowlists, full job examples). Summary checklist extended.
- **`agents/AGENTS-github-actions.md`** — required-control sections for all four. Six new entries in "What Requires Human Review" (lowering `fail-on-severity`, removing any of the four controls, runner image bumps, weakening `SECURITY.md`).
- **`README.md`** — OpenSSF Scorecard + REUSE badges added at the top. Ecosystem-doc summary row extended.

## Repo state changes (out-of-band, applied alongside this PR)

- `gh api -X PUT repos/jordanconway/package-manager-hardening/private-vulnerability-reporting` → enabled
- Branch protection updated: `Dependency review` added to required status checks on `main`

## Verification

- `zizmor .` and `zizmor --persona=auditor .` — clean (still! despite adding a new workflow)
- `uv run pytest tests/ -q` — 202/202
- `reuse lint` — 52/52 files compliant
- `markdownlint-cli2 "**/*.md"` — 29 files, 0 errors

## Notes for the next PR

This was the "no-infra" tier. Tier 2 (provenance + verification: `gh attestation verify`, `actions/attest-build-provenance` for any release artifacts, OIDC publishing patterns for PyPI / npm / GHCR) is the natural follow-up — also zero-infra, but slightly more involved per ecosystem.

🤖 Generated with [pi](https://github.com/badlogic/lemmy/tree/main/apps/pi)
