### PR TITLE
ci+docs: add CodeQL SAST and Hypothesis fuzzing (Scorecard SAST + Fuzzing)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,8 @@ jobs:
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443
+            api.deps.dev:443
+            api.securityscorecards.dev:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: github/codeql-action/init@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3.35.4
+      - uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
         with:
           languages: ${{ matrix.language }}
           # security-extended adds queries with lower precision/recall but
@@ -56,6 +56,6 @@ jobs:
           queries: security-extended
           build-mode: none
 
-      - uses: github/codeql-action/analyze@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3.35.4
+      - uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+#
+# SPDX-License-Identifier: MIT
+
+# CodeQL static analysis (SAST) for Python.
+# Satisfies OpenSSF Scorecard's "SAST" check and surfaces results in the
+# Security tab. Free for public repos; included with GHAS for private.
+#
+# Docs: https://docs.github.com/en/code-security/code-scanning
+
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "23 6 * * 1"  # weekly, Monday 06:23 UTC (offset from Scorecard)
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: CodeQL analysis (${{ matrix.language }})
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write   # upload SARIF to the Security tab
+      contents: read           # checkout
+      actions: read            # codeql reads workflow context
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, actions]
+    steps:
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        with:
+          # CodeQL contacts many endpoints to download query packs and submit
+          # results; documented to require audit mode rather than block.
+          egress-policy: audit
+          disable-sudo: true
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: github/codeql-action/init@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3.35.4
+        with:
+          languages: ${{ matrix.language }}
+          # security-extended adds queries with lower precision/recall but
+          # higher coverage; appropriate for a security-tooling repo.
+          queries: security-extended
+          build-mode: none
+
+      - uses: github/codeql-action/analyze@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3.35.4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 __pycache__/
 *.pyc
 *.pyo
+.pytest_cache/
+.hypothesis/
 
 # Node.js
 node_modules/

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ cp -r skills/harden-packages ~/.claude/skills/
 |-----|--------|
 | [Dependabot](docs/dependabot.md) | Cooldown configuration per ecosystem, semver-level delay, known Terraform provider bug |
 | [Harden-Runner](docs/harden-runner.md) | Runtime CI egress control, audit → block mode, per-ecosystem `allowed-endpoints` |
-| [GitHub Actions](docs/github-actions.md) | SHA pinning, runner image pinning, least-privilege permissions, expression injection, OIDC, CODEOWNERS, `persist-credentials: false`, workflow concurrency, zizmor static analysis, dependency-review on PRs, OpenSSF Scorecard, `SECURITY.md` + private vulnerability reporting |
+| [GitHub Actions](docs/github-actions.md) | SHA pinning, runner image pinning, least-privilege permissions, expression injection, OIDC, CODEOWNERS, `persist-credentials: false`, workflow concurrency, zizmor static analysis, CodeQL SAST, fuzzing, dependency-review on PRs, OpenSSF Scorecard, `SECURITY.md` + private vulnerability reporting |
 | [Container Images](docs/docker.md) | Base image digest pinning, official images, distroless, Docker Scout, Cosign, Dependabot |
 
 ### AI assistant tooling

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,3 +46,27 @@ Out of scope:
 
 - Vulnerabilities in third-party tools the docs reference (Dependabot, Harden-Runner, zizmor, uv, etc.) — please report those directly to the upstream projects
 - Issues in user repositories that adopt these recommendations
+
+## Security posture
+
+This repository's posture is publicly visible:
+
+- **OpenSSF Scorecard** — see the badge in [README.md](README.md). Score is updated weekly and on every push to `main` via [`.github/workflows/scorecard.yml`](.github/workflows/scorecard.yml).
+- **CodeQL** — SAST runs on every push, every PR to `main`, and weekly. Findings appear in the Security tab.
+- **Dependency review** — every PR is gated on `actions/dependency-review-action` (`fail-on-severity: high`, GPL/AGPL denylist).
+- **zizmor** — every push and PR is gated on workflow static analysis at `--min-severity=medium`.
+- **Harden-Runner** — every CI job runs under runtime egress control (`block` mode with explicit allowlists, or `audit` mode where `block` is impractical).
+- **Secret scanning + push protection** — enabled on the repo.
+- **Private vulnerability reporting** — enabled (this is what the link above uses).
+- **Property-based fuzzing** — [`tests/test_fuzz.py`](tests/test_fuzz.py) uses Hypothesis to fuzz the audit-script parsers against adversarial inputs.
+
+## Known Scorecard trade-offs
+
+Two Scorecard checks are deliberately not satisfied for this repository, and the corresponding code-scanning alerts are dismissed as `won't fix`:
+
+- **Code-Review** — Scorecard expects every changeset to be approved by a different person than the author. This repository follows a deliberate single-maintainer policy: the owner merges their own PRs and may push directly to `main`. Branch protection enforces required status checks, linear history, conversation resolution, and no force-push, but does **not** require a separate reviewer (`enforce_admins: false`, no `required_pull_request_reviews`). Contributors should expect their own PRs to land via the same flow once they have write access. If you would prefer multi-maintainer review for higher-risk changes, open an issue.
+- **Maintained** — Scorecard penalises repositories younger than 90 days. This will resolve with time and is not actionable.
+
+## OpenSSF Best Practices Badge
+
+A self-certification at <https://www.bestpractices.dev/> is on the roadmap. Once awarded, the badge will appear next to the Scorecard badge in [README.md](README.md). Until then, Scorecard's `CII-Best-Practices` check will report 0; this is a known gap rather than a missing control.

--- a/agents/AGENTS-github-actions.md
+++ b/agents/AGENTS-github-actions.md
@@ -32,6 +32,32 @@ concurrency:
 
 For release / deploy workflows where in-flight runs should complete, keep the `group:` but set `cancel-in-progress: false`.
 
+## Static analysis: CodeQL (SAST)
+
+Every repository must run CodeQL on every push, every PR to the default branch, and on a weekly schedule. SAST is a Scorecard requirement and CodeQL is the canonical implementation for GitHub.
+
+- Use a separate workflow file: `.github/workflows/codeql.yml`. Do not bundle into `ci.yml`.
+- Enable at minimum the `actions` language plus the primary application language(s). `actions` complements zizmor by catching workflow vulnerabilities CodeQL surfaces differently.
+- Use `queries: security-extended` for security-focused repos. Do not use `security-and-quality` (noisier code-quality findings dilute the signal).
+- `egress-policy` must be `audit`, not `block` — CodeQL fetches query packs from `objects.githubusercontent.com` and submits results back to the API. A fixed allowlist is impractical.
+- `permissions: security-events: write` is required to upload SARIF; do not omit.
+- Do not delete the workflow, narrow the language matrix, or downgrade `security-extended` to `security-and-quality` without explicit human approval.
+
+## Fuzzing
+
+Every repository with parser-style code (anything that consumes external file content, network input, or user-controlled strings) must have a fuzzing integration. This satisfies Scorecard's `Fuzzing` check and catches a class of bugs unit tests routinely miss.
+
+Minimum viable per language:
+
+- **Python** — `hypothesis` property-based tests in `tests/`. Pin in `pyproject.toml [dependency-groups].dev` so it's hash-verified via the lockfile.
+- **Go** — `go test -fuzz` targets (`func FuzzXxx(f *testing.F)`); run as part of CI.
+- **Rust** — `cargo-fuzz` targets under `fuzz/`.
+- **C / C++** — ClusterFuzzLite or OSS-Fuzz integration.
+
+The contract under test is usually "parser must not crash on arbitrary input." Property tests are not full fuzzing campaigns but Scorecard accepts them, and they catch ReDoS, encoding edge cases, and crash-on-empty-input bugs that unit tests miss.
+
+Do not remove the fuzzing target / dev-dep / test file without explicit human approval.
+
 ## Static analysis: zizmor
 
 Every repository must run [`zizmor`](https://docs.zizmor.sh) against `.github/workflows/` in CI as a required status check. zizmor catches the controls in this file plus many others (template injection, mutable reusable-workflow refs, dangerous triggers, secrets exposed to forks, etc.) and is the canonical static analyser for this domain.
@@ -206,5 +232,8 @@ The following changes must not be made autonomously and require explicit human a
 - Removing the zizmor job, lowering its `--min-severity`, or suppressing a finding without a documented justification
 - Removing the dependency-review job, lowering its `fail-on-severity`, or removing it from required status checks
 - Removing the Scorecard workflow, or changing its `egress-policy` away from `audit`
+- Removing the CodeQL workflow, narrowing its language matrix, or downgrading from `security-extended` to `security-and-quality`
+- Removing the fuzzing integration (`hypothesis` dev-dep + `tests/test_fuzz.py` for Python; equivalents for other languages)
 - Bumping a runner image (`ubuntu-24.04` → `ubuntu-26.04`, etc.) without confirming the matrix still passes
 - Removing or weakening `SECURITY.md` or disabling private vulnerability reporting
+- Dismissing a Scorecard / CodeQL finding without a documented justification in `SECURITY.md`

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -349,6 +349,90 @@ Minimum `SECURITY.md` content:
 
 Without this, researchers either file public issues (worst case) or never report at all.
 
+## Static analysis with CodeQL (SAST)
+
+[CodeQL](https://docs.github.com/en/code-security/code-scanning) is GitHub's semantic SAST engine. It catches the bugs that line-level linters can't — SQL injection, path traversal, deserialisation flaws, hard-coded credentials, unsafe deserialisation, command injection. Free for public repos; included with GitHub Advanced Security for private. Findings appear in the Security tab and (for PRs) inline in the diff.
+
+Also satisfies OpenSSF Scorecard's `SAST` check, which scores 0 if no SAST tool runs on commits.
+
+Add it as a separate workflow file. Use the `python` and `actions` languages (the latter scans the workflows themselves):
+
+```yaml
+# .github/workflows/codeql.yml
+name: CodeQL
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "23 6 * * 1"
+permissions: {}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  analyze:
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, actions]
+    steps:
+      - uses: step-security/harden-runner@<sha> # v2
+        with:
+          egress-policy: audit  # CodeQL fetches query packs; block is impractical
+          disable-sudo: true
+      - uses: actions/checkout@<sha> # v4
+        with:
+          persist-credentials: false
+      - uses: github/codeql-action/init@<sha> # v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended  # higher coverage for security-focused repos
+          build-mode: none            # Python/Actions: no compilation needed
+      - uses: github/codeql-action/analyze@<sha> # v3
+        with:
+          category: "/language:${{ matrix.language }}"
+```
+
+Use `queries: security-extended` for security-focused repos; the default `security-and-quality` adds noisier code-quality findings on top. Keep `egress-policy: audit` — CodeQL legitimately fetches query packs from `objects.githubusercontent.com` and posts results back to the API, and a fixed allowlist is impractical to maintain.
+
+Languages worth enabling beyond your application code:
+
+- **`actions`** — catches workflow vulnerabilities (template injection, mutable refs) that complement zizmor
+- **`javascript-typescript`** — even for backend repos, scans any frontend / build scripts
+- **`go` / `java-kotlin` / `csharp` / `cpp` / `swift` / `ruby` / `rust`** — each language has dedicated query packs
+
+## Fuzzing
+
+OpenSSF Scorecard's `Fuzzing` check scores 0 if it finds no fuzzer integration. For most repos, the lowest-friction satisfying pattern is:
+
+- **Python**: Hypothesis property-based tests in `tests/`. Scorecard recognises `import hypothesis` as fuzzing.
+- **Go**: built-in `go test -fuzz` tests (`func FuzzXxx(f *testing.F)`).
+- **Rust**: `cargo-fuzz` targets in `fuzz/`.
+- **C / C++ / anything else**: ClusterFuzzLite or OSS-Fuzz integration.
+
+Property-based tests are not full fuzzing campaigns, but they catch the same class of bugs (regex catastrophic backtracking, parser crashes on adversarial inputs, encoding edge cases) and integrate cleanly into the existing test job. Example for a Python repo with parser-style code:
+
+```python
+# tests/test_fuzz.py
+from hypothesis import given, settings, strategies as st
+
+@given(content=st.text(max_size=4096))
+@settings(max_examples=200, deadline=500)
+def test_parser_never_raises(content):
+    # Property: parser must not raise on arbitrary input
+    result = my_module.parse(content)
+    assert result is None or isinstance(result, dict)
+```
+
+Add `hypothesis==<version>` to your dev dependency group so it's hash-verified via the lockfile.
+
 ## Static analysis with zizmor
 
 [`zizmor`](https://docs.zizmor.sh) is a static analyser for GitHub Actions workflows. It catches the issues described above plus dozens more (template injection, unpinned actions, dangerous triggers, missing `permissions:`, mutable reusable-workflow refs, secrets exposed to forks, and so on). Run it locally and in CI:
@@ -427,7 +511,9 @@ Dependabot understands SHA-pinned actions and will propose updates with both the
 | Block vulnerable PR deps | `actions/dependency-review-action` as required check on PRs |
 | External posture scoring | `ossf/scorecard-action` weekly + on push to main, with badge |
 | Vulnerability disclosure | `SECURITY.md` + GitHub private vulnerability reporting enabled |
-| Static analysis | `zizmor` job in CI; SHA-pinned, `--min-severity=medium` |
+| Static analysis (workflows) | `zizmor` job in CI; SHA-pinned, `--min-severity=medium` |
+| Static analysis (code) | `CodeQL` workflow; `security-extended` queries; `audit` egress |
+| Fuzzing | Hypothesis (Python) / `go test -fuzz` (Go) / `cargo-fuzz` (Rust) / OSS-Fuzz (C/C++) |
 | Avoid `pull_request_target` | Use `pull_request` unless write access is explicitly needed |
 | Prevent expression injection | Pass untrusted values via `env:`, not `${{ }}` in `run:` |
 | OIDC for cloud auth | `id-token: write` + federated identity; no long-lived keys |

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -273,6 +273,17 @@ It's PR-only, free, and requires no infrastructure. It also writes a summary com
 
 Make the job a required status check on `main` so it cannot be merged around. Tune `fail-on-severity` (`critical | high | moderate | low`) to your project's risk tolerance.
 
+**Endpoint requirements**: `dependency-review-action` **v4.9.0+** queries `api.deps.dev` and `api.securityscorecards.dev` for vulnerability and Scorecard data, in addition to the standard `api.github.com` / `github.com` / `objects.githubusercontent.com`. v4.8.x did not need these. A Dependabot bump from 4.8.x → 4.9.x will fail in `block` mode with `fetch failed` until the two new endpoints are added to the allowlist:
+
+```yaml
+allowed-endpoints: >
+  api.github.com:443
+  github.com:443
+  objects.githubusercontent.com:443
+  api.deps.dev:443
+  api.securityscorecards.dev:443
+```
+
 **Prerequisite**: `dependency-review-action` requires Dependabot security updates to be enabled on the repo (not just the always-on dependency graph). Without it, every run fails with `Dependency review is not supported on this repository. Please ensure that Dependency graph is enabled`. Enable via Settings → Code security → "Dependabot security updates", or:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.10"
 dev = [
     "ruff==0.15.12",
     "pytest==9.0.3",
+    "hypothesis==6.131.0",
 ]
 
 [tool.uv]

--- a/skills/harden-packages/SKILL.md
+++ b/skills/harden-packages/SKILL.md
@@ -695,6 +695,39 @@ Use this section only if `audit.py` cannot be run. It replicates what the script
   4. Add both files to `REUSE.toml`
   5. Switch the workflow step to `npm ci --ignore-scripts`
 
+### Static application security testing (CodeQL)
+
+- Is there a `.github/workflows/codeql.yml` running `github/codeql-action`? Flag absence as ❌.
+- Does it trigger on `push`, `pull_request` to the default branch, **and** a `schedule` (weekly)? Missing `schedule` is ⚠️ — catches drift after dependency bumps.
+- Does the language matrix include `actions` plus the project's primary language(s)? Missing `actions` is ⚠️ — it complements zizmor by catching workflow vulnerabilities.
+- Is `queries: security-extended` set? Bare default or `security-and-quality` is ⚠️ for security-focused repos (the latter dilutes signal with code-quality findings).
+- Is `egress-policy: audit` set on Harden-Runner? CodeQL legitimately fetches query packs and submits results; `block` is impractical and will break the workflow. Flag `block` here as ⚠️.
+- Is `permissions: security-events: write` granted? Without it the SARIF upload silently no-ops.
+- Note: CodeQL is free for public repos and included with GHAS for private. Mention this when recommending it for private repos.
+
+### Fuzzing
+
+- Is there a fuzzing integration appropriate to the language? Flag absence as ❌ (Scorecard scores 0 for `Fuzzing` without one).
+  - **Python**: `hypothesis` in `[dependency-groups].dev` + at least one `@given(...)` test. Property-based tests count.
+  - **Go**: `func FuzzXxx(f *testing.F)` targets, run as part of CI.
+  - **Rust**: `cargo-fuzz` targets in `fuzz/`.
+  - **C/C++**: ClusterFuzzLite or OSS-Fuzz.
+- For parser-style code (anything consuming external file content, network input, user-controlled strings), the contract under test should be "parser must not crash on arbitrary input." Confirm tests cover the actual parsing surface, not trivial functions.
+- Is the fuzzing dependency hash-verified via the lockfile? `hypothesis` should be in `pyproject.toml [dependency-groups].dev` and locked in `uv.lock`, never installed inline.
+
+### Interpreting Scorecard findings
+
+When reviewing a repo's Scorecard score (Security tab → Code scanning → ScorecardID alerts), some findings are deliberately not actionable for legitimate reasons. Recognise and document these rather than chasing a green-only score:
+
+- **`Maintained` < 90 days**: a time-based finding for new repos. Auto-resolves; document and dismiss as `won't fix` if the repo is genuinely active. No code change.
+- **`Code-Review` 0/N approved changesets**: Scorecard wants every PR approved by a different person. Conflicts with deliberate single-maintainer policies. If the user explicitly wants to merge their own PRs, document the trade-off in `SECURITY.md` and dismiss with `won't fix` + comment.
+- **`CII-Best-Practices` 0**: requires self-certification at <https://www.bestpractices.dev/>. Cannot be automated; document as a roadmap item with the registration URL. Once awarded, add the badge to README.
+- **`Pinned-Dependencies` 9 ("npmCommand not pinned by hash")**: see CI tool installs section above; fix by switching to `npm ci --ignore-scripts` from a committed lockfile.
+- **`Token-Permissions` < 10**: a workflow grants more than `contents: read` without job-level overrides. Fix at the workflow level.
+- **`Dangerous-Workflow` finding**: `pull_request_target` with checkout-of-head, or expression injection. Treat as urgent — these are RCE-equivalent.
+
+When dismissing a Scorecard alert, always set `dismissed_reason: won't fix` (the API only accepts `false positive`, `won't fix`, `used in tests`) and include a `dismissed_comment` linking to the documented justification in `SECURITY.md`. The comment must be ≤ 280 chars.
+
 ### SECURITY.md and private vulnerability reporting
 
 - Is there a `SECURITY.md` at the repo root? Flag absence as ❌.

--- a/skills/harden-packages/audit.py
+++ b/skills/harden-packages/audit.py
@@ -147,13 +147,18 @@ def audit_nodejs(root):
 
     # packageManager field can override manager detection
     pkg = {}
+    pkg = {}
     try:
         import json as _json
 
-        pkg = _json.loads(read(r / "package.json"))
+        loaded = _json.loads(read(r / "package.json"))
+        if isinstance(loaded, dict):
+            pkg = loaded
     except Exception:
         pass
     pm_field = pkg.get("packageManager", "")
+    if not isinstance(pm_field, str):
+        pm_field = ""
     if pm_field.startswith("pnpm"):
         manager = "pnpm"
     elif pm_field.startswith("yarn"):
@@ -433,13 +438,18 @@ def audit_php(root):
     try:
         import json as _json
 
-        composer_json = _json.loads(read(r / "composer.json"))
+        loaded = _json.loads(read(r / "composer.json"))
+        if isinstance(loaded, dict):
+            composer_json = loaded
     except Exception:
         pass
 
     loose = []
     for section in ("require", "require-dev"):
-        for pkg_name, ver in composer_json.get(section, {}).items():
+        section_data = composer_json.get(section, {})
+        if not isinstance(section_data, dict):
+            continue
+        for pkg_name, ver in section_data.items():
             if pkg_name == "php":
                 continue
             if re.search(r"[\^~>*]|\|\|", str(ver)):
@@ -451,7 +461,8 @@ def audit_php(root):
     }
 
     # roave/security-advisories
-    has_roave = "roave/security-advisories" in composer_json.get("require-dev", {})
+    require_dev = composer_json.get("require-dev", {})
+    has_roave = isinstance(require_dev, dict) and "roave/security-advisories" in require_dev
     findings["roave_security_advisories"] = {
         "status": status(has_roave),
         "present": has_roave,

--- a/tests/test_fuzz.py
+++ b/tests/test_fuzz.py
@@ -1,0 +1,214 @@
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Property-based fuzz tests for the audit script.
+
+Uses Hypothesis to generate adversarial inputs for the per-ecosystem audit
+functions and the parsing helpers. The contract under test is simple but
+important: no audit function should ever raise an unhandled exception,
+regardless of the contents of the manifests, lockfiles, or workflows it
+encounters in a target repository.
+
+This catches:
+  - Regex catastrophic backtracking (ReDoS) in the helpers
+  - Encoding / decoding issues in `read()`
+  - Crashes on malformed YAML, TOML, JSON, or workflow files
+  - Crashes on empty / huge / null-byte-laden inputs
+
+Satisfies OpenSSF Scorecard's "Fuzzing" check (recognises Hypothesis as a
+fuzzing tool for Python projects).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "harden-packages"))
+
+import audit  # noqa: E402  (path injection above)
+
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+# Reasonably-sized text blobs that include the kinds of bytes we expect to
+# trip up regex and encoding paths: nulls, unicode, very long lines, etc.
+adversarial_text = st.text(
+    alphabet=st.characters(blacklist_categories=()),  # full unicode incl. control chars
+    min_size=0,
+    max_size=4096,
+)
+
+# Filenames the audit functions look for, plus arbitrary names to make sure
+# extra files don't perturb behaviour.
+manifest_names = st.sampled_from(
+    [
+        "package.json",
+        "pnpm-workspace.yaml",
+        ".npmrc",
+        "pyproject.toml",
+        "uv.lock",
+        "requirements.txt",
+        "go.mod",
+        "Cargo.toml",
+        "Cargo.lock",
+        "composer.json",
+        "composer.lock",
+        "Gemfile",
+        "Gemfile.lock",
+        "pom.xml",
+        "build.gradle",
+        "build.gradle.kts",
+        "main.tf",
+        "versions.tf",
+        ".terraform.lock.hcl",
+        ".github/dependabot.yml",
+        ".github/workflows/ci.yml",
+        ".github/workflows/release.yml",
+    ]
+)
+
+
+@st.composite
+def synthetic_repo(draw, tmp_path_factory):
+    """Build a tmp directory populated with random manifest files."""
+    root = tmp_path_factory.mktemp("fuzz_repo")
+    files = draw(
+        st.lists(
+            st.tuples(manifest_names, adversarial_text),
+            min_size=0,
+            max_size=8,
+            unique_by=lambda t: t[0],
+        )
+    )
+    for name, content in files:
+        target = root / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            target.write_text(content, encoding="utf-8", errors="replace")
+        except (OSError, ValueError):
+            # Some inputs (e.g. embedded NULs on certain filesystems) can
+            # fail to write — skip them, the audit script handles missing
+            # files via its `read()` helper anyway.
+            pass
+    return root
+
+
+# ---------------------------------------------------------------------------
+# Helper-level properties
+# ---------------------------------------------------------------------------
+
+
+@given(content=adversarial_text, pattern=st.sampled_from([
+    r"version\s*=\s*\"([^\"]+)\"",
+    r"^\s*([A-Za-z0-9_-]+)\s*=",
+    r"\$\{\{\s*[^}]+\s*\}\}",
+    r"#\s*v\d+\.\d+\.\d+",
+]))
+@settings(max_examples=200, deadline=500)
+def test_grep_never_raises(content, pattern):
+    """audit.grep must return a bool for any input; never raise, never hang."""
+    result = audit.grep(content, pattern)
+    assert isinstance(result, bool)
+
+
+@given(content=adversarial_text)
+@settings(max_examples=200, deadline=500)
+def test_find_value_never_raises(content):
+    """audit.find_value must return str|None for any input; never raise."""
+    result = audit.find_value(content, r"version\s*=\s*\"([^\"]+)\"")
+    assert result is None or isinstance(result, str)
+
+
+@given(name=st.text(min_size=0, max_size=200))
+@settings(
+    max_examples=100,
+    deadline=500,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+def test_is_gitignored_never_raises(tmp_path, name):
+    """audit.is_gitignored handles arbitrary names without crashing."""
+    (tmp_path / ".gitignore").write_text("node_modules\n*.pyc\n")
+    result = audit.is_gitignored(str(tmp_path), name)
+    assert isinstance(result, bool)
+
+
+# ---------------------------------------------------------------------------
+# Audit-function-level properties
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "audit_fn",
+    [
+        audit.audit_nodejs,
+        audit.audit_python,
+        audit.audit_go,
+        audit.audit_rust,
+        audit.audit_php,
+        audit.audit_ruby,
+        audit.audit_terraform,
+        audit.audit_maven,
+        audit.audit_gradle,
+        audit.audit_harden_runner,
+    ],
+)
+@given(content=adversarial_text, name=manifest_names)
+@settings(
+    max_examples=50,
+    deadline=2000,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+def test_audit_function_never_crashes(tmp_path, audit_fn, content, name):
+    """No per-ecosystem audit function should crash on adversarial manifests."""
+    target = tmp_path / name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        target.write_text(content, encoding="utf-8", errors="replace")
+    except (OSError, ValueError):
+        pytest.skip("filesystem rejected the generated content")
+    # Result shape varies per function; we only assert no exception escapes.
+    audit_fn(str(tmp_path))
+
+
+@given(content=adversarial_text)
+@settings(
+    max_examples=50,
+    deadline=2000,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+def test_audit_dependabot_never_crashes(tmp_path, content):
+    """audit_dependabot must handle arbitrary dependabot.yml content."""
+    db = tmp_path / ".github" / "dependabot.yml"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        db.write_text(content, encoding="utf-8", errors="replace")
+    except (OSError, ValueError):
+        pytest.skip("filesystem rejected the generated content")
+    audit.audit_dependabot(str(tmp_path), [])
+
+
+@given(content=adversarial_text)
+@settings(
+    max_examples=50,
+    deadline=2000,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+def test_detect_ecosystems_never_crashes(tmp_path, content):
+    """detect_ecosystems must handle arbitrary marker-file content."""
+    for marker in ["package.json", "pyproject.toml", "go.mod", "Cargo.toml"]:
+        try:
+            (tmp_path / marker).write_text(content, encoding="utf-8", errors="replace")
+        except (OSError, ValueError):
+            pass
+    result = audit.detect_ecosystems(str(tmp_path))
+    assert isinstance(result, list)

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,15 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -28,6 +37,20 @@ wheels = [
 ]
 
 [[package]]
+name = "hypothesis"
+version = "6.131.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/79/82eaf131f58a5c434830f0c196995a5071531765c51ebc8aaff493002b5e/hypothesis-6.131.0.tar.gz", hash = "sha256:4b807daeeee47852edfd9818ba0e33df14902f1b78a5524f1a3fb71f80c7cec3", size = 430541, upload-time = "2025-04-10T04:33:07.742Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/43/b5e5d397e1ece9b71584c1771214b4a643d81fa8f197d4ff5938295ead25/hypothesis-6.131.0-py3-none-any.whl", hash = "sha256:734959017e3ee4ef8f0ecb4e5169c8f4cf96dc83a997d2edf01fb5350f5bf2f4", size = 495720, upload-time = "2025-04-10T04:33:04.097Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -43,6 +66,7 @@ source = { virtual = "." }
 
 [package.dev-dependencies]
 dev = [
+    { name = "hypothesis" },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -51,6 +75,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "hypothesis", specifier = "==6.131.0" },
     { name = "pytest", specifier = "==9.0.3" },
     { name = "ruff", specifier = "==0.15.12" },
 ]
@@ -123,6 +148,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
     { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
     { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes 3 of 5 open Scorecard alerts in the Security tab and dismisses the other 2 with documented justifications.

| # | Rule | Sev | Disposition |
|---|---|---|---|
| 6 | SAST | medium | **Fixed** — new CodeQL workflow (`python` + `actions`) |
| 5 | Fuzzing | medium | **Fixed** — `hypothesis` dev-dep + `tests/test_fuzz.py` (15 property tests) |
| 4 | CII-Best-Practices | low | **Roadmap** — requires self-cert at <https://www.bestpractices.dev/>; documented in `SECURITY.md` |
| 3 | Maintained | high | **Dismissed** (won't fix) — time-based, repo <90 days; auto-resolves |
| 2 | Code-Review | high | **Dismissed** (won't fix) — single-maintainer policy is deliberate; documented in `SECURITY.md` |

## CodeQL workflow

- Languages: `python` + `actions` matrix. Adding `actions` complements zizmor by surfacing workflow vulns through CodeQL's semantic engine.
- Triggers: push to `main`, PR to `main`, weekly Mon 06:23 UTC (offset from Scorecard's 05:37).
- `queries: security-extended` (right setting for a security-tooling repo; `security-and-quality` is noisier).
- `egress-policy: audit` (CodeQL fetches query packs and posts results back; `block` is impractical).
- All actions SHA-pinned; `permissions: {}` at workflow with explicit per-job grants and inline justifications.

## Hypothesis fuzzing

- New `hypothesis==6.131.0` in `pyproject.toml [dependency-groups].dev`, hash-verified via `uv.lock`.
- `tests/test_fuzz.py` with property-based tests for:
  - Helpers: `audit.grep` / `find_value` / `is_gitignored` (regex DoS, encoding edge cases)
  - Every per-ecosystem `audit_*` function (10 ecosystems)
  - `audit_dependabot`, `detect_ecosystems`
- Contract under test: **audit functions must not raise on adversarial manifest content**.
- 200 examples per helper test, 50 per ecosystem test — fast enough for every CI commit.
- Total tests now **217** (was 202).

## SECURITY.md expansion

- New "Security posture" section enumerating every visible control with links.
- New "Known Scorecard trade-offs" section documenting the `Code-Review` and `Maintained` dismissals.
- New "OpenSSF Best Practices Badge" section pointing to bestpractices.dev as a roadmap item.

## Recommendation propagation

- **`skills/harden-packages/SKILL.md`** — three new audit sections: SAST (CodeQL), Fuzzing, and "Interpreting Scorecard findings" (covers the Maintained / Code-Review / CII / Pinned-Dependencies / Token-Permissions / Dangerous-Workflow finding classes, plus the `gh api` dismissal pattern with the 280-char comment limit gotcha).
- **`docs/github-actions.md`** — full "Static analysis with CodeQL (SAST)" and "Fuzzing" sections with copy-paste-ready YAML, per-language fuzzer recommendations (Python/Go/Rust/C++). Summary checklist extended.
- **`agents/AGENTS-github-actions.md`** — required sections for both controls, plus four new "What Requires Human Review" entries (removing CodeQL, narrowing language matrix, downgrading queries, removing fuzzing, dismissing without documenting).
- **`README.md`** — ecosystem-doc summary row extended.
- **`.gitignore`** — `.pytest_cache/` + `.hypothesis/`.

## Repo state changes (out-of-band)

- Scorecard alert #3 dismissed via `gh api` (reason: `won't fix`, comment links to SECURITY.md justification)
- Scorecard alert #2 dismissed via `gh api` (same)
- Branch protection updated: `CodeQL analysis (python)` and `CodeQL analysis (actions)` added to required status checks on `main`. Scorecard remains intentionally **not** required (it doesn't run on PRs).

## Verification

- `zizmor .` and `zizmor --persona=auditor .` — clean (now scans 4 workflows: ci, codeql, scorecard, dependabot)
- `uv run pytest tests/ -q` — **217/217**
- `reuse lint` — 56/56
- `markdownlint-cli2 "**/*.md"` — 29 files, 0 errors

Once merged + the next Scorecard run completes, the score should improve on `SAST` (0→10), `Fuzzing` (0→10), `Maintained` (when timer expires), and the dismissals will stop showing as open alerts.

🤖 Generated with [pi](https://github.com/badlogic/lemmy/tree/main/apps/pi)
