### PR TITLE
docs: CHANGELOG.md + SemVer release process (Best Practices change-control)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,74 @@
+<!--
+SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+SPDX-License-Identifier: MIT
+-->
+
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-05-12
+
+Initial tagged release. The project has been developed openly on `main` since its first commit; this release establishes a stable baseline that downstream consumers (humans, AI coding assistants, and CI integrations) can pin to.
+
+### Added — Per-ecosystem hardening recommendations
+
+Reference docs under [`docs/`](docs/) covering exact-version pinning, lockfile commits, hash verification, minimum release age (cooldown), CI install commands, and audit tooling for:
+
+- **Node.js** (npm, pnpm, yarn, bun) — [`docs/nodejs.md`](docs/nodejs.md)
+- **Python** (pip, uv) — [`docs/python.md`](docs/python.md)
+- **Go** modules — [`docs/go.md`](docs/go.md)
+- **Rust / Cargo** — [`docs/rust.md`](docs/rust.md)
+- **PHP / Composer** — [`docs/php.md`](docs/php.md)
+- **Ruby / Bundler** — [`docs/ruby.md`](docs/ruby.md)
+- **JVM** (Maven, Gradle — Java and Kotlin) — [`docs/jvm.md`](docs/jvm.md)
+- **Terraform / OpenTofu** — [`docs/terraform.md`](docs/terraform.md)
+- **Docker** — [`docs/docker.md`](docs/docker.md)
+- **Helm** — [`docs/helm.md`](docs/helm.md)
+
+### Added — Cross-cutting controls
+
+- **GitHub Actions** hardening — [`docs/github-actions.md`](docs/github-actions.md): SHA pinning with `# vX.Y.Z` comments, runner image pinning (`ubuntu-24.04`), least-privilege `permissions: {}` with per-job grants and inline justifications, expression-injection prevention, OIDC, CODEOWNERS, `persist-credentials: false`, workflow concurrency, [zizmor](https://github.com/woodruffw/zizmor) static analysis, [CodeQL](https://docs.github.com/en/code-security/code-scanning) SAST, fuzzing, [`actions/dependency-review-action`](https://github.com/actions/dependency-review-action) on PRs, [OpenSSF Scorecard](https://github.com/ossf/scorecard-action), and `SECURITY.md` + private vulnerability reporting.
+- **Dependabot** configuration patterns — [`docs/dependabot.md`](docs/dependabot.md): rolling cooldowns (`"7 days"`), per-ecosystem grouping, `github-actions` ecosystem caveats.
+- **Harden-Runner** runtime egress control — [`docs/harden-runner.md`](docs/harden-runner.md): `block` mode with explicit `allowed-endpoints`; documented `audit`-mode exceptions (Scorecard, CodeQL).
+
+### Added — `harden-packages` skill
+
+- [`skills/harden-packages/SKILL.md`](skills/harden-packages/SKILL.md): an LLM-callable runbook for auditing and remediating any of the supported ecosystems in a target repository.
+- [`skills/harden-packages/audit.py`](skills/harden-packages/audit.py): a Python CLI that emits structured JSON findings per ecosystem. Inputs: `--path` (defaults to `.`), `--pretty`. Outputs: a top-level JSON object keyed by detected ecosystem, with per-control `status` (`ok` / `fail` / `warn`), evidence, and remediation hints. Defensive parsing — fuzz-tested against malformed JSON / TOML inputs.
+
+### Added — `AGENTS-*` files
+
+Per-ecosystem rules for AI coding assistants operating on user repositories — [`agents/`](agents/): `nodejs`, `python`, `go`, `rust`, `php`, `ruby`, `jvm`, `terraform`, `docker`, `helm`, `github-actions`. Each documents what changes require explicit human review.
+
+### Added — This repository's own security posture
+
+- All required CI status checks on `main`: REUSE, ruff, pytest (3.10 + 3.12), markdown lint, link check, zizmor, dependency review, CodeQL (python + actions).
+- Branch protection enforcing the above with linear history, conversation resolution, and no force-push.
+- Dependabot enabled for `github-actions`, `uv`, and `npm` ecosystems with 7-day rolling cooldown.
+- Property-based fuzz tests in [`tests/test_fuzz.py`](tests/test_fuzz.py) using Hypothesis (15 tests, 10 ecosystems covered).
+- [`SECURITY.md`](SECURITY.md) with private vulnerability reporting enabled.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) covering required checks, coding standards, and the propagation checklist for new controls.
+- OpenSSF Scorecard workflow, weekly + on push to `main`.
+- Python toolchain managed by `uv` with `[dependency-groups].dev` (PEP 735) and a hash-verified `uv.lock`.
+- Node.js dev dependencies (markdownlint) hash-verified via committed `package-lock.json`; CI uses `npm ci --ignore-scripts`.
+
+### Security
+
+No publicly known runtime vulnerabilities have been reported against this project at the time of this release.
+
+### Known trade-offs
+
+Documented in [`SECURITY.md`](SECURITY.md):
+
+- Single-maintainer policy — Scorecard `Code-Review` check is intentionally not satisfied.
+- `Maintained` Scorecard check is time-based and will resolve once the repository is 90 days old.
+- OpenSSF Best Practices badge: `Passing` self-certification in progress.
+
+[Unreleased]: https://github.com/jordanconway/package-manager-hardening/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/jordanconway/package-manager-hardening/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,16 @@ SPDX-License-Identifier: MIT
 
 For files without comment syntax (JSON, lockfiles, binary), add an entry to [`REUSE.toml`](REUSE.toml).
 
+### Releases and changelog
+
+User-visible changes go in [`CHANGELOG.md`](CHANGELOG.md) under the `[Unreleased]` section as part of the same PR. The changelog follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project follows [Semantic Versioning](https://semver.org/):
+
+- **MAJOR** when a recommendation is removed, the `audit.py` JSON schema changes incompatibly, or guidance reverses direction.
+- **MINOR** when new ecosystems, controls, or audit fields are added in a backward-compatible way.
+- **PATCH** for documentation fixes, typo corrections, link repairs, and bug fixes that don't change recommended behaviour.
+
+Releases are cut by the maintainer via `git tag vX.Y.Z` + a corresponding GitHub Release whose body links to the relevant `CHANGELOG.md` section.
+
 ## Code of conduct
 
 Be respectful, be specific, assume good faith. Personal attacks, harassment, or discriminatory language will result in the issue / PR being closed without further engagement.

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The lockfile provides a partial mitigation â€” it pins exact resolved versions â
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contribution guide: how to file issues, the local checks every PR must pass, the SHA-pinning conventions for actions, the licensing/REUSE requirements, and the per-ecosystem propagation checklist for new recommendations. For security vulnerabilities, see [SECURITY.md](SECURITY.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contribution guide: how to file issues, the local checks every PR must pass, the SHA-pinning conventions for actions, the licensing/REUSE requirements, and the per-ecosystem propagation checklist for new recommendations. For security vulnerabilities, see [SECURITY.md](SECURITY.md). For release history, see [CHANGELOG.md](CHANGELOG.md).
 
 ## Reference Links
 


### PR DESCRIPTION
## Summary

Establishes the release-management apparatus required for the OpenSSF Best Practices Passing-tier Change Control criteria: `version_unique`, `version_semver`, `version_tags`, `release_notes`, and `release_notes_vulns`.

After this PR is merged, cutting `v0.1.0` becomes one command:

```bash
gh release create v0.1.0 --title "v0.1.0" --notes-file CHANGELOG.md --target main
```

## CHANGELOG.md

- Keep a Changelog 1.1.0 format, SemVer 2.0.0.
- `v0.1.0` entry summarises the first stable baseline:
  - 10 ecosystem hardening guides (Node.js, Python, Go, Rust, PHP, Ruby, JVM, Terraform, Docker, Helm)
  - 3 cross-cutting guides (GitHub Actions, Dependabot, Harden-Runner)
  - The `harden-packages` skill — SKILL.md + `audit.py` CLI with documented JSON schema
  - 11 `AGENTS-*.md` files for AI assistants
  - This repo's own posture: branch protection, 8 required checks, Dependabot, Hypothesis fuzz tests (15 tests / 10 ecosystems), `SECURITY.md`, `CONTRIBUTING.md`, Scorecard, CodeQL (python + actions), hash-verified `uv.lock` + `package-lock.json`
  - Documented Scorecard trade-offs (single-maintainer, <90-day repo)
- States that no publicly known runtime vulnerabilities have been reported at release time (satisfies `release_notes_vulns`).
- Includes `[Unreleased]` / `[0.1.0]` GitHub compare links.

## CONTRIBUTING.md

New "Releases and changelog" section codifies:

- All user-visible changes go in `[Unreleased]` in the same PR.
- SemVer rules adapted for a docs/recommendations project:
  - **MAJOR** — recommendation removed, `audit.py` JSON schema breaks, guidance reverses
  - **MINOR** — new ecosystems / controls / audit fields (backward-compatible)
  - **PATCH** — doc fixes, typo / link repairs, behaviour-preserving bug fixes
- Releases cut via `git tag vX.Y.Z` + matching GitHub Release linking the changelog section.

## README

Added `CHANGELOG.md` link in the Contributing section.

## Verification

- `reuse lint` — clean (CHANGELOG.md has SPDX header)
- `markdownlint-cli2 "**/*.md"` — 31 files, 0 errors

## Best Practices badge — copy-paste justifications

After merging this PR and running `gh release create v0.1.0 ...`, fill the form:

**`repo_interim`** — Met
> All development happens via pull requests on `main`, visible at <https://github.com/jordanconway/package-manager-hardening/pulls?q=is%3Apr> and the full commit history at <https://github.com/jordanconway/package-manager-hardening/commits/main>. Interim versions between tagged releases are always available.

**`version_unique`** — Met
> Each release has a unique version identifier. Releases are listed at <https://github.com/jordanconway/package-manager-hardening/releases>. Current release: `v0.1.0`.

**`version_semver`** — Met
> Releases follow Semantic Versioning 2.0.0 (<https://semver.org/spec/v2.0.0.html>). The MAJOR / MINOR / PATCH semantics for this project are documented in [CONTRIBUTING.md → Releases and changelog](https://github.com/jordanconway/package-manager-hardening/blob/main/CONTRIBUTING.md#releases-and-changelog).

**`version_tags`** — Met
> Each release is identified by a Git tag of the form `vX.Y.Z`. Tags are visible at <https://github.com/jordanconway/package-manager-hardening/tags>.

**`release_notes`** — Met
> Human-readable release notes are maintained in [CHANGELOG.md](https://github.com/jordanconway/package-manager-hardening/blob/main/CHANGELOG.md) (Keep a Changelog format) and mirrored to the GitHub Release page at <https://github.com/jordanconway/package-manager-hardening/releases>. They are not raw VCS log output.

**`release_notes_vulns`** — Met
> The `Security` section of each `CHANGELOG.md` release entry identifies any publicly known runtime vulnerabilities fixed in that release. The `v0.1.0` entry records that no publicly known runtime vulnerabilities have been reported against this project to date. Future releases will list any CVE-assigned issues fixed in that release in the same section.

🤖 Generated with [pi](https://github.com/badlogic/lemmy/tree/main/apps/pi)
