### PR TITLE
docs: add OpenSSF Best Practices Passing badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ Documented in [`SECURITY.md`](SECURITY.md):
 
 - Single-maintainer policy — Scorecard `Code-Review` check is intentionally not satisfied.
 - `Maintained` Scorecard check is time-based and will resolve once the repository is 90 days old.
-- OpenSSF Best Practices badge: `Passing` self-certification in progress.
+- OpenSSF Best Practices badge: **Passing** tier awarded (project 12822).
 
 [Unreleased]: https://github.com/jordanconway/package-manager-hardening/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/jordanconway/package-manager-hardening/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ SPDX-License-Identifier: MIT
 # Package Manager Security Hardening
 
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/jordanconway/package-manager-hardening/badge)](https://scorecard.dev/viewer/?uri=github.com/jordanconway/package-manager-hardening)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12822/badge)](https://www.bestpractices.dev/projects/12822)
 [![REUSE status](https://api.reuse.software/badge/github.com/jordanconway/package-manager-hardening)](https://api.reuse.software/info/github.com/jordanconway/package-manager-hardening)
 
 A reference for hardening software supply chains across npm, pnpm, Yarn, Bun, pip, uv, Go modules, Cargo, Maven, Gradle, Terraform, and OpenTofu.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -82,4 +82,4 @@ Two Scorecard checks are deliberately not satisfied for this repository, and the
 
 ## OpenSSF Best Practices Badge
 
-A Passing-tier self-certification at <https://www.bestpractices.dev/> is in progress. Once awarded, the badge will appear next to the Scorecard badge in [README.md](README.md). Scorecard's `CII-Best-Practices` check will report 0 until the badge is awarded; this is a known gap rather than a missing control.
+This project has earned the OpenSSF Best Practices **Passing** badge: <https://www.bestpractices.dev/projects/12822>. The badge is displayed in [README.md](README.md). Silver and Gold tiers are on the roadmap.


### PR DESCRIPTION
Project 12822 was awarded the Passing-tier badge: <https://www.bestpractices.dev/projects/12822>

- README: badge added between OpenSSF Scorecard and REUSE.
- SECURITY.md: 'OpenSSF Best Practices Badge' section updated from 'in progress' to 'awarded'; Silver/Gold noted as roadmap.
- CHANGELOG.md: 'Known trade-offs' bullet in the v0.1.0 entry updated.

Scorecard's `CII-Best-Practices` check should rise to 10 on the next scheduled run.

🤖 Generated with [pi](https://github.com/badlogic/lemmy/tree/main/apps/pi)