### PR TITLE
ci(scorecard): pass SCORECARD_TOKEN to fix Branch-Protection check

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -49,6 +49,13 @@ jobs:
           results_format: sarif
           # Publish results to OpenSSF so the README badge works.
           publish_results: true
+          # Fine-grained PAT with Administration: Read-only on this repo.
+          # Required because the default GITHUB_TOKEN cannot read classic
+          # branch protection rules (the API the Branch-Protection check
+          # uses). Without this, the action fails with:
+          #   "some github tokens can't read classic branch protection rules"
+          # Docs: https://github.com/ossf/scorecard-action/blob/main/docs/authentication/fine-grained-auth-token.md
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Scorecard workflow now passes a fine-grained `SCORECARD_TOKEN` to `ossf/scorecard-action` so the `Branch-Protection` check can read the classic branch-protection API. Without this the entire run failed with `some github tokens can't read classic branch protection rules`. Token requires only `Administration: Read-only` scope on this repo. Documented in [docs/github-actions.md](docs/github-actions.md), the harden-packages skill audit checklist, and AGENTS-github-actions.md.
+
 ## [0.1.0] - 2026-05-12
 
 Initial tagged release. The project has been developed openly on `main` since its first commit; this release establishes a stable baseline that downstream consumers (humans, AI coding assistants, and CI integrations) can pin to.

--- a/agents/AGENTS-github-actions.md
+++ b/agents/AGENTS-github-actions.md
@@ -90,6 +90,8 @@ Every repository must publish an OpenSSF Scorecard score via `ossf/scorecard-act
 
 The Scorecard workflow uses `egress-policy: audit`, not `block` — the analyser legitimately contacts dozens of ecosystem endpoints. Do not change to `block`.
 
+The `ossf/scorecard-action` step **must** receive `repo_token: ${{ secrets.SCORECARD_TOKEN }}` if the repository has any branch protection configured. The default `GITHUB_TOKEN` cannot read the classic branch-protection API and the entire run will fail with `some github tokens can't read classic branch protection rules`. The token must be a fine-grained PAT scoped **only** to `Administration: Read-only` on the target repo — never a classic PAT, never broader scopes, never named `GITHUB_TOKEN` (reserved). When recommending the Scorecard workflow, include the secret-creation step in the same instruction.
+
 A dropping Scorecard score is a regression that must be triaged like any other CI failure. Common causes: a new unpinned action, a removed branch protection rule, a permission grant added without justification.
 
 ## Vulnerability disclosure: SECURITY.md

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -333,6 +333,9 @@ jobs:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
+          # Required for the Branch-Protection check (default GITHUB_TOKEN
+          # cannot read classic branch protection rules). See note below.
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
       - uses: github/codeql-action/upload-sarif@<sha> # v3
         with:
           sarif_file: results.sarif
@@ -345,6 +348,32 @@ Add the badge to your README so the score is publicly visible:
 ```
 
 Scorecard's `egress-policy` must be `audit`, not `block` — the analyser legitimately contacts dozens of endpoints (deps.dev, OSV, npm, PyPI, etc.) to score your project against the ecosystem.
+
+### Fine-grained PAT for the Branch-Protection check
+
+Without a `repo_token`, the scheduled run fails with:
+
+```text
+internal error: error during branchesHandler.setup:
+some github tokens can't read classic branch protection rules
+```
+
+The default `GITHUB_TOKEN` minted for a workflow does not have the scopes needed to read the classic branch-protection API (`/repos/:o/:r/branches/:branch/protection`). Mint a **fine-grained personal access token** with **only** the scopes Scorecard needs:
+
+1. <https://github.com/settings/personal-access-tokens/new>
+2. Resource owner: your user or org
+3. Repository access: **Only select repositories** → the repo being scored
+4. Repository permissions: **Administration: Read-only** (the only permission needed)
+5. Set an expiration (1 year is reasonable; calendar-reminder to rotate)
+6. Save the token as a repository secret named `SCORECARD_TOKEN`:
+
+   ```bash
+   gh secret set SCORECARD_TOKEN --repo <owner>/<repo>
+   ```
+
+7. Pass it via `repo_token: ${{ secrets.SCORECARD_TOKEN }}` on the `ossf/scorecard-action` step.
+
+Do **not** use a classic PAT or grant additional scopes — a token with more access than needed defeats the purpose. Do not name the secret `GITHUB_TOKEN` (reserved). Per the upstream docs: <https://github.com/ossf/scorecard-action/blob/main/docs/authentication/fine-grained-auth-token.md>.
 
 ## SECURITY.md and private vulnerability reporting
 

--- a/skills/harden-packages/SKILL.md
+++ b/skills/harden-packages/SKILL.md
@@ -676,6 +676,7 @@ Use this section only if `audit.py` cannot be run. It replicates what the script
 - Is `publish_results: true` set so the README badge resolves?
 - Is the workflow's `egress-policy` set to `audit` (not `block`)? Scorecard legitimately contacts deps.dev, OSV, npm, PyPI, etc. and cannot run under a fixed allowlist. Flag `block` here as ⚠️.
 - Is the Scorecard badge in the README so the score is publicly visible?
+- Is `repo_token: ${{ secrets.SCORECARD_TOKEN }}` set on the action step? Without it, the `Branch-Protection` check fails the entire run with `some github tokens can't read classic branch protection rules`. The token must be a fine-grained PAT with **only** `Administration: Read-only` on the target repo (no other scopes). Flag absence as ❌ if branch protection is configured; ⚠️ otherwise.
 - Note that a *dropping* Scorecard score is a regression to triage — not just a green/red flag at a point in time.
 - **Common Scorecard `Pinned-Dependencies` finding**: inline `npm install pkg@ver` and `pip install pkg==x.y.z` in workflow steps are version-pinned but not hash-verified, and Scorecard scores them ~9/10. The fix is to commit a lockfile and switch to `npm ci --ignore-scripts` / `uv sync --frozen --group dev`. Recommend this whenever you see inline tool installs in a workflow.
 


### PR DESCRIPTION
## Problem

Scheduled Scorecard runs were failing with:

```
internal error: error during branchesHandler.setup:
some github tokens can't read classic branch protection rules
```

The default `GITHUB_TOKEN` minted for a workflow doesn't have the scope needed to read `/repos/:o/:r/branches/:branch/protection`. Once we configured branch protection in PR #3, Scorecard's `Branch-Protection` check started failing the entire run.

Per upstream: <https://github.com/ossf/scorecard-action/blob/main/docs/authentication/fine-grained-auth-token.md>

## Workflow change

Added `repo_token: ${{ secrets.SCORECARD_TOKEN }}` on the `ossf/scorecard-action` step with an inline comment documenting why.

## Operational change (out-of-band, completed)

- Fine-grained PAT `scorecard-action-package-manager-hardening` with **only** `Administration: Read-only` on this repo, 1-year expiration.
- Stored as repo secret `SCORECARD_TOKEN` via `gh secret set`.

## Documentation propagation

| File | What was added |
|---|---|
| `docs/github-actions.md` | New "Fine-grained PAT for the Branch-Protection check" subsection with PAT-creation URL, exact permission, `gh secret set` command, workflow YAML snippet, and warnings against classic PATs / broader scopes / reserved secret names |
| `skills/harden-packages/SKILL.md` | New audit-checklist item in OpenSSF Scorecard section with severity guidance |
| `agents/AGENTS-github-actions.md` | Required-rule paragraph mandating `SCORECARD_TOKEN` when branch protection is configured |
| `CHANGELOG.md` | `[Unreleased] / Fixed` entry |

## Verification

- zizmor clean, REUSE clean, markdownlint 31 files / 0 errors
- Effect takes hold once both the secret is set (done) AND this workflow change lands; next scheduled / push run should complete and the `Branch-Protection` score should rise

🤖 Generated with [pi](https://github.com/badlogic/lemmy/tree/main/apps/pi)