### PR TITLE
ci(fuzz): add Atheris coverage-guided fuzzing (Scorecard Fuzzing 0→10)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -88,3 +88,26 @@ updates:
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 3
+
+  # Atheris fuzzer (separate from main dev deps because it only ships
+  # wheels for Linux + Python <= 3.11; lives in fuzz/requirements.txt
+  # with --require-hashes pinning).
+  - package-ecosystem: "pip"
+    directory: "/fuzz"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "python"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+#
+# SPDX-License-Identifier: MIT
+
+# Coverage-guided fuzzing with Atheris.
+#
+# Runs each fuzz harness in fuzz/ for a fixed wall-clock budget. Atheris ships
+# pre-built wheels only for Linux x86_64 + Python 3.11, so the job pins to
+# ubuntu-24.04 + Python 3.11 specifically.
+#
+# This workflow is deliberately scheduled (weekly + manual), not gated on PRs:
+#   - PR runs use Hypothesis (tests/test_fuzz.py) which is fast and broad.
+#   - This run is slower, deeper, and finds the inputs property tests miss.
+#
+# Crashes upload as artifacts and fail the run.
+
+name: Fuzz
+
+on:
+  schedule:
+    - cron: "17 7 * * 1"  # weekly, Monday 07:17 UTC
+  workflow_dispatch:
+    inputs:
+      duration:
+        description: "Per-harness fuzz budget in seconds"
+        required: false
+        default: "180"
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fuzz:
+    name: Atheris (${{ matrix.harness }})
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read  # checkout
+    strategy:
+      fail-fast: false
+      matrix:
+        harness:
+          - fuzz_audit_parsers
+          - fuzz_audit_helpers
+    steps:
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: block
+          disable-sudo: true
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            files.pythonhosted.org:443
+            pypi.org:443
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: "3.11"  # atheris wheels only ship for <= 3.11
+
+      - name: Install Atheris
+        run: python -m pip install --require-hashes -r fuzz/requirements.txt
+
+      - name: Run ${{ matrix.harness }}
+        env:
+          # Indirect through an env var to avoid template-injection risk
+          # (zizmor: template-injection). Validated below.
+          DURATION_INPUT: ${{ github.event.inputs.duration || '180' }}
+          HARNESS: ${{ matrix.harness }}
+        run: |
+          # Reject anything that isn't a positive integer.
+          if ! [[ "$DURATION_INPUT" =~ ^[0-9]+$ ]]; then
+            echo "::error::duration must be a positive integer; got: $DURATION_INPUT" >&2
+            exit 1
+          fi
+          mkdir -p fuzz-artifacts
+          # -atheris_runs=0 lets it run forever; -max_total_time bounds it.
+          # -artifact_prefix puts crash inputs in a known directory.
+          python "fuzz/${HARNESS}.py" \
+            -atheris_runs=0 \
+            "-max_total_time=${DURATION_INPUT}" \
+            -artifact_prefix=fuzz-artifacts/
+
+      - if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: crash-${{ matrix.harness }}
+          path: fuzz-artifacts/
+          retention-days: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Coverage-guided fuzz harnesses in [`fuzz/`](fuzz/) using Atheris (libFuzzer for Python). Two harnesses cover every parser and helper. Hash-pinned in [`fuzz/requirements.txt`](fuzz/requirements.txt) and [`fuzz/requirements.in`](fuzz/requirements.in). Documented in [`fuzz/README.md`](fuzz/README.md).
+- New scheduled workflow [`.github/workflows/fuzz.yml`](.github/workflows/fuzz.yml) runs each Atheris harness for 3 minutes weekly (Monday 07:17 UTC) and on `workflow_dispatch`. Crashes upload as artifacts and fail the run. Pinned to `ubuntu-24.04` + Python 3.11 (Atheris wheel constraint).
+
 ### Fixed
 
 - Scorecard workflow now passes a fine-grained `SCORECARD_TOKEN` to `ossf/scorecard-action` so the `Branch-Protection` check can read the classic branch-protection API. Without this the entire run failed with `some github tokens can't read classic branch protection rules`. Token requires only `Administration: Read-only` scope on this repo. Documented in [docs/github-actions.md](docs/github-actions.md), the harden-packages skill audit checklist, and AGENTS-github-actions.md.
+- Documentation correction: previous releases stated that Hypothesis property-based tests satisfy OpenSSF Scorecard's `Fuzzing` check for Python. **They do not** — Scorecard's Python detector matches `import atheris` only (Hypothesis is recognised for Erlang / Haskell / Elixir / Gleam, but not Python). Corrected in `docs/github-actions.md`, `skills/harden-packages/SKILL.md`, `agents/AGENTS-github-actions.md`, and `SECURITY.md`.
 
 ## [0.1.0] - 2026-05-12
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -71,7 +71,8 @@ This repository's posture is publicly visible:
 - **Harden-Runner** — every CI job runs under runtime egress control (`block` mode with explicit allowlists, or `audit` mode where `block` is impractical).
 - **Secret scanning + push protection** — enabled on the repo.
 - **Private vulnerability reporting** — enabled (this is what the link above uses).
-- **Property-based fuzzing** — [`tests/test_fuzz.py`](tests/test_fuzz.py) uses Hypothesis to fuzz the audit-script parsers against adversarial inputs.
+- **Property-based fuzzing** — [`tests/test_fuzz.py`](tests/test_fuzz.py) uses Hypothesis to fuzz the audit-script parsers against adversarial inputs on every PR.
+- **Coverage-guided fuzzing** — [`fuzz/`](fuzz/) holds Atheris (libFuzzer) harnesses, run weekly via [`.github/workflows/fuzz.yml`](.github/workflows/fuzz.yml). Atheris is what satisfies OpenSSF Scorecard's `Fuzzing` check (Hypothesis is not Scorecard-recognised for Python).
 
 ## Known Scorecard trade-offs
 

--- a/agents/AGENTS-github-actions.md
+++ b/agents/AGENTS-github-actions.md
@@ -45,16 +45,17 @@ Every repository must run CodeQL on every push, every PR to the default branch, 
 
 ## Fuzzing
 
-Every repository with parser-style code (anything that consumes external file content, network input, or user-controlled strings) must have a fuzzing integration. This satisfies Scorecard's `Fuzzing` check and catches a class of bugs unit tests routinely miss.
+Every repository with parser-style code (anything that consumes external file content, network input, or user-controlled strings) must have a fuzzing integration recognised by [OpenSSF Scorecard's `Fuzzing` check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#fuzzing). The detection is narrow and language-specific. **Hypothesis is not recognised for Python** — do not add only Hypothesis and assume the check is satisfied.
 
 Minimum viable per language:
 
-- **Python** — `hypothesis` property-based tests in `tests/`. Pin in `pyproject.toml [dependency-groups].dev` so it's hash-verified via the lockfile.
-- **Go** — `go test -fuzz` targets (`func FuzzXxx(f *testing.F)`); run as part of CI.
+- **Python** — `import atheris` in a `fuzz/` harness, hash-pinned in `fuzz/requirements.txt`. Atheris is coverage-guided libFuzzer; only ships wheels for Linux x86_64 + Python ≤ 3.11. Run on a scheduled workflow (weekly), not per-PR (too slow). Keep Hypothesis property tests in `tests/test_fuzz.py` alongside — different bug class, fast enough for PRs.
+- **Go** — `func FuzzXxx(f *testing.F)` targets; run as part of CI.
 - **Rust** — `cargo-fuzz` targets under `fuzz/`.
-- **C / C++** — ClusterFuzzLite or OSS-Fuzz integration.
+- **C / C++** — `LLVMFuzzerTestOneInput` harnesses, integrated via ClusterFuzzLite (`.clusterfuzzlite/Dockerfile`) or OSS-Fuzz.
+- **Cross-language** — ClusterFuzzLite is the most flexible answer; OSS-Fuzz is the most thorough; both are recognised regardless of language.
 
-The contract under test is usually "parser must not crash on arbitrary input." Property tests are not full fuzzing campaigns but Scorecard accepts them, and they catch ReDoS, encoding edge cases, and crash-on-empty-input bugs that unit tests miss.
+The contract under test is usually "parser must not crash on arbitrary input." Property tests are not full fuzzing campaigns but they catch ReDoS, encoding edge cases, and crash-on-empty-input bugs that unit tests miss.
 
 Do not remove the fuzzing target / dev-dep / test file without explicit human approval.
 
@@ -235,7 +236,7 @@ The following changes must not be made autonomously and require explicit human a
 - Removing the dependency-review job, lowering its `fail-on-severity`, or removing it from required status checks
 - Removing the Scorecard workflow, or changing its `egress-policy` away from `audit`
 - Removing the CodeQL workflow, narrowing its language matrix, or downgrading from `security-extended` to `security-and-quality`
-- Removing the fuzzing integration (`hypothesis` dev-dep + `tests/test_fuzz.py` for Python; equivalents for other languages)
+- Removing the fuzzing integration (Atheris harness in `fuzz/` for Python; `func Fuzz*` for Go; `cargo-fuzz` for Rust; `LLVMFuzzerTestOneInput` for C/C++; ClusterFuzzLite for any), or removing the Hypothesis property suite that complements it
 - Bumping a runner image (`ubuntu-24.04` → `ubuntu-26.04`, etc.) without confirming the matrix still passes
 - Removing or weakening `SECURITY.md` or disabling private vulnerability reporting
 - Dismissing a Scorecard / CodeQL finding without a documented justification in `SECURITY.md`

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -450,14 +450,93 @@ Languages worth enabling beyond your application code:
 
 ## Fuzzing
 
-OpenSSF Scorecard's `Fuzzing` check scores 0 if it finds no fuzzer integration. For most repos, the lowest-friction satisfying pattern is:
+OpenSSF Scorecard's [`Fuzzing` check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#fuzzing) scores 0 if it finds no fuzzer integration. **The detection is narrow and language-specific** — for Python in particular, Hypothesis is *not* recognised (despite being recognised for Erlang / Haskell / Elixir / Gleam). The recognised options are:
 
-- **Python**: Hypothesis property-based tests in `tests/`. Scorecard recognises `import hypothesis` as fuzzing.
-- **Go**: built-in `go test -fuzz` tests (`func FuzzXxx(f *testing.F)`).
-- **Rust**: `cargo-fuzz` targets in `fuzz/`.
-- **C / C++ / anything else**: ClusterFuzzLite or OSS-Fuzz integration.
+| Language | Recognised pattern |
+|---|---|
+| Python | `import atheris` in any `*.py` file |
+| Go | `func Fuzz<Name>(f *testing.F)` in any `*_test.go` |
+| Rust | `cargo-fuzz` targets under `fuzz/` |
+| C / C++ | `LLVMFuzzerTestOneInput` in `*.c` / `*.cc` / `*.cpp` |
+| JavaScript / TypeScript | `fast-check` import |
+| Erlang / Haskell / Elixir / Gleam | property-based test imports (QuickCheck, Hedgehog, PropCheck, etc.) |
+| Any language | `.clusterfuzzlite/Dockerfile` exists, or repo listed at <https://github.com/google/oss-fuzz/tree/master/projects> |
 
-Property-based tests are not full fuzzing campaigns, but they catch the same class of bugs (regex catastrophic backtracking, parser crashes on adversarial inputs, encoding edge cases) and integrate cleanly into the existing test job. Example for a Python repo with parser-style code:
+### Python: Atheris + Hypothesis is the right combination
+
+The two tools serve different purposes; do both:
+
+- **Atheris** — coverage-guided libFuzzer for Python. Watches which branches each input exercises and mutates toward unexplored ones. Catches deep parser bugs, ReDoS, encoding edge cases. Recognised by Scorecard. Wheels only ship for Linux x86_64 + Python ≤ 3.11; doesn't run on macOS without building from source.
+- **Hypothesis** — property-based testing. Blind random generation against declarative invariants. Fast, runs on every PR, catches contract violations property tests are good at. **Not** recognised by Scorecard.
+
+Layout:
+
+```text
+fuzz/
+  fuzz_<surface>.py     # one harness per surface
+  requirements.txt      # hash-pinned: atheris==<x>
+  README.md             # how to run, how to reproduce crashes
+tests/
+  test_fuzz.py          # Hypothesis property suite, runs on every PR
+```
+
+Minimal Atheris harness:
+
+```python
+# fuzz/fuzz_parser.py
+import sys, atheris
+with atheris.instrument_imports():
+    from my_module import parse
+
+def TestOneInput(data: bytes) -> None:
+    fdp = atheris.FuzzedDataProvider(data)
+    content = fdp.ConsumeUnicode(sys.maxsize)
+    try:
+        parse(content)
+    except Exception as exc:
+        raise AssertionError(f"parse raised: {exc}") from exc
+
+atheris.Setup(sys.argv, TestOneInput)
+atheris.Fuzz()
+```
+
+Run continuously on a schedule (not per-PR — minutes-to-hours of runtime):
+
+```yaml
+# .github/workflows/fuzz.yml
+on:
+  schedule:
+    - cron: "17 7 * * 1"  # weekly
+  workflow_dispatch:
+jobs:
+  fuzz:
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        harness: [fuzz_parser]
+    steps:
+      - uses: actions/checkout@<sha>
+        with: { persist-credentials: false }
+      - uses: actions/setup-python@<sha>
+        with: { python-version: "3.11" }  # atheris wheels: <= 3.11 only
+      - run: python -m pip install --require-hashes -r fuzz/requirements.txt
+      - run: |
+          mkdir -p fuzz-artifacts
+          python fuzz/${{ matrix.harness }}.py \
+            -atheris_runs=0 -max_total_time=180 \
+            -artifact_prefix=fuzz-artifacts/
+      - if: failure()
+        uses: actions/upload-artifact@<sha>
+        with: { name: crash-${{ matrix.harness }}, path: fuzz-artifacts/ }
+```
+
+The `--require-hashes` install is mandatory: this is exactly the supply-chain pattern this project documents elsewhere. Pin Atheris in `fuzz/requirements.txt` with hashes (regenerate via `pip-compile --generate-hashes`).
+
+### When Hypothesis-only is acceptable
+
+If the project is a docs / configuration / non-parser repo with no untrusted-input attack surface, a Hypothesis-only suite is reasonable and you can mark `Fuzzing` as a known-acceptable 0 in `SECURITY.md` (similar to the documented `Code-Review` and `Maintained` trade-offs). Don't add Atheris just for the score — it's only worth it if you have parser-style code that benefits from coverage-guided exploration.
+
+Property-based tests still catch the bugs Atheris can't (declarative invariants, contract violations) and are fast enough for every PR:
 
 ```python
 # tests/test_fuzz.py
@@ -466,12 +545,9 @@ from hypothesis import given, settings, strategies as st
 @given(content=st.text(max_size=4096))
 @settings(max_examples=200, deadline=500)
 def test_parser_never_raises(content):
-    # Property: parser must not raise on arbitrary input
     result = my_module.parse(content)
     assert result is None or isinstance(result, dict)
 ```
-
-Add `hypothesis==<version>` to your dev dependency group so it's hash-verified via the lockfile.
 
 ## Static analysis with zizmor
 
@@ -553,7 +629,7 @@ Dependabot understands SHA-pinned actions and will propose updates with both the
 | Vulnerability disclosure | `SECURITY.md` + GitHub private vulnerability reporting enabled |
 | Static analysis (workflows) | `zizmor` job in CI; SHA-pinned, `--min-severity=medium` |
 | Static analysis (code) | `CodeQL` workflow; `security-extended` queries; `audit` egress |
-| Fuzzing | Hypothesis (Python) / `go test -fuzz` (Go) / `cargo-fuzz` (Rust) / OSS-Fuzz (C/C++) |
+| Fuzzing | Atheris (Python, coverage-guided) + Hypothesis (Python, property-based) / `go test -fuzz` (Go) / `cargo-fuzz` (Rust) / OSS-Fuzz / ClusterFuzzLite (C/C++/any) |
 | Avoid `pull_request_target` | Use `pull_request` unless write access is explicitly needed |
 | Prevent expression injection | Pass untrusted values via `env:`, not `${{ }}` in `run:` |
 | OIDC for cloud auth | `id-token: write` + federated identity; no long-lived keys |

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,61 @@
+<!--
+SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+SPDX-License-Identifier: MIT
+-->
+
+# Fuzz harnesses
+
+Coverage-guided fuzz harnesses for `skills/harden-packages/audit.py`, using [Atheris](https://github.com/google/atheris) (libFuzzer for Python).
+
+## Why two fuzz suites?
+
+| Suite | Tool | Goal | Where |
+|---|---|---|---|
+| Property-based | [Hypothesis](https://hypothesis.readthedocs.io/) | Catch crashes and contract violations on adversarial *shapes* of input. Runs on every PR. Fast. | [`tests/test_fuzz.py`](../tests/test_fuzz.py) |
+| Coverage-guided | [Atheris](https://github.com/google/atheris) (libFuzzer) | Drive the parser toward unexplored branches using coverage feedback. Catches crashes property tests miss. Runs on a schedule. | [`fuzz/`](.) |
+
+The two are complementary. Hypothesis is *blind* — it samples inputs from a strategy. Atheris is *guided* — it watches which branches each input exercises and mutates toward unexplored ones. Property tests cover declarative invariants ("audit must not crash"); coverage-guided fuzzing finds the inputs that satisfy those invariants in interesting ways.
+
+This setup also satisfies [OpenSSF Scorecard's `Fuzzing` check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#fuzzing) — the check's Python detector matches `import atheris`, **not** Hypothesis. (See [docs/github-actions.md](../docs/github-actions.md#fuzzing) for context.)
+
+## Running locally
+
+Atheris ships pre-built wheels for Linux x86_64 + Python ≤ 3.11. On macOS or with Python ≥ 3.12 you'll need to build from source against an LLVM/clang install — easier to use the CI workflow or a Linux VM/container.
+
+```bash
+# Linux + Python 3.11
+python3.11 -m venv .venv-fuzz
+source .venv-fuzz/bin/activate
+pip install atheris
+
+# Run a single harness for 60 seconds
+python fuzz/fuzz_audit_parsers.py -atheris_runs=0 -max_total_time=60
+
+# Or fixed iteration count
+python fuzz/fuzz_audit_helpers.py -atheris_runs=100000
+```
+
+Reproducing a crash:
+
+```bash
+# Atheris prints the crash input as a base64 blob on failure;
+# save it as crash-XXXX and replay:
+python fuzz/fuzz_audit_parsers.py crash-XXXX
+```
+
+## Continuous fuzzing in CI
+
+The scheduled workflow [`.github/workflows/fuzz.yml`](../.github/workflows/fuzz.yml) runs each harness for a few minutes weekly and on `workflow_dispatch`. Crashes upload as artifacts and fail the run.
+
+## Adding a harness
+
+1. Create `fuzz/fuzz_<surface>.py` with `import atheris`, an `instrument_imports()` block around `import audit`, and a `TestOneInput(data: bytes)` function.
+2. Add it to the `fuzz.yml` matrix.
+3. Update [`tests/test_fuzz.py`](../tests/test_fuzz.py) with a Hypothesis property test for the same surface (different bug class, complements rather than replaces).
+
+## What to do with crashes
+
+Every crash is a bug. The audit functions' contract is "must not raise on any input from a target repository's filesystem". If the input is something the audit function should reject explicitly (e.g. binary garbage in a YAML file), the function should detect and skip it cleanly, not crash.
+
+Fix the underlying defensive-parsing bug in `audit.py`, then add the crash input to the corpus (`fuzz/corpus/<harness>/`) so it's regression-tested forever.

--- a/fuzz/fuzz_audit_helpers.py
+++ b/fuzz/fuzz_audit_helpers.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Coverage-guided fuzz harness for skills/harden-packages/audit.py helpers.
+
+Targets the parsing helpers (`grep`, `find_value`, `is_gitignored`,
+`detect_ecosystems`) that every per-ecosystem audit function depends on.
+A regex DoS or encoding crash in any of these blast-radiuses across every
+ecosystem.
+
+Run locally:
+
+    pip install atheris
+    python fuzz/fuzz_audit_helpers.py -atheris_runs=100000
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import tempfile
+
+import atheris
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "skills" / "harden-packages"))
+
+with atheris.instrument_imports():
+    import audit  # noqa: E402
+
+
+def TestOneInput(data: bytes) -> None:
+    fdp = atheris.FuzzedDataProvider(data)
+    choice = fdp.ConsumeIntInRange(0, 3)
+
+    if choice == 0:
+        # Regex DoS surface: arbitrary patterns against arbitrary content.
+        pattern = fdp.ConsumeUnicode(128)
+        content = fdp.ConsumeUnicode(2048)
+        try:
+            audit.grep(content, pattern)
+        except Exception as exc:
+            # Bad patterns from user-supplied workflow text are realistic.
+            # ReDoS / re.error are bugs; everything else is a bug.
+            raise AssertionError(
+                f"grep raised on adversarial input: {type(exc).__name__}: {exc}"
+            ) from exc
+
+    elif choice == 1:
+        pattern = fdp.ConsumeUnicode(128)
+        content = fdp.ConsumeUnicode(2048)
+        try:
+            audit.find_value(content, pattern)
+        except Exception as exc:
+            raise AssertionError(
+                f"find_value raised on adversarial input: {type(exc).__name__}: {exc}"
+            ) from exc
+
+    elif choice == 2:
+        # is_gitignored writes a .gitignore and queries it.
+        gi_content = fdp.ConsumeUnicode(2048)
+        path = fdp.ConsumeUnicode(256)
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            try:
+                (root / ".gitignore").write_text(gi_content, errors="replace")
+                audit.is_gitignored(str(root), path)
+            except OSError:
+                return
+            except Exception as exc:
+                raise AssertionError(
+                    f"is_gitignored raised on adversarial input: "
+                    f"{type(exc).__name__}: {exc}"
+                ) from exc
+
+    else:
+        # Random repo-shape: throw arbitrary file names into a tmp dir, then
+        # let detect_ecosystems decide what's there.
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            for _ in range(fdp.ConsumeIntInRange(0, 8)):
+                name = fdp.ConsumeUnicode(64)
+                # Skip path-traversal attempts; the function isn't expected
+                # to defend against malicious filesystems.
+                if "/" in name or ".." in name or not name.strip():
+                    continue
+                try:
+                    (root / name).write_bytes(fdp.ConsumeBytes(256))
+                except OSError:
+                    continue
+            try:
+                audit.detect_ecosystems(str(root))
+            except Exception as exc:
+                raise AssertionError(
+                    f"detect_ecosystems raised on adversarial input: "
+                    f"{type(exc).__name__}: {exc}"
+                ) from exc
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzz/fuzz_audit_parsers.py
+++ b/fuzz/fuzz_audit_parsers.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Coverage-guided fuzz harnesses for skills/harden-packages/audit.py.
+
+Run locally:
+
+    pip install atheris
+    python fuzz/fuzz_audit_parsers.py -atheris_runs=100000
+
+Or via the scheduled GitHub Actions workflow `.github/workflows/fuzz.yml`.
+
+Each ecosystem audit function consumes one or more manifest / lockfile / workflow
+files in a directory. The harness writes random bytes to the file the audit
+function expects, runs the function, and asserts no unhandled exception is
+raised. Atheris's libFuzzer instrumentation evolves inputs toward unexplored
+branches \u2014 catches a different class of bug than the property-based suite in
+tests/test_fuzz.py (which is *not* recognised by OpenSSF Scorecard's Fuzzing
+check).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import tempfile
+
+import atheris
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "skills" / "harden-packages"))
+
+with atheris.instrument_imports():
+    import audit  # noqa: E402
+
+
+# Maps each audit function to the per-repo file(s) the function reads.
+TARGETS = {
+    "audit_nodejs": ("package.json",),
+    "audit_python": ("pyproject.toml", "requirements.txt"),
+    "audit_go": ("go.mod", "go.sum"),
+    "audit_rust": ("Cargo.toml", "Cargo.lock"),
+    "audit_php": ("composer.json", "composer.lock"),
+    "audit_ruby": ("Gemfile", "Gemfile.lock"),
+    "audit_terraform": ("main.tf", ".terraform.lock.hcl"),
+    "audit_maven": ("pom.xml",),
+    "audit_gradle": ("build.gradle", "settings.gradle"),
+    "audit_harden_runner": (".github/workflows/ci.yml",),
+    "audit_dependabot": (".github/dependabot.yml",),
+}
+
+
+def TestOneInput(data: bytes) -> None:
+    """Atheris entry point. Each call: random bytes -> every audit function."""
+    fdp = atheris.FuzzedDataProvider(data)
+    # Pick which audit function to drive, plus content for each of its files.
+    fn_name = fdp.PickValueInList(list(TARGETS.keys()))
+    files = TARGETS[fn_name]
+
+    with tempfile.TemporaryDirectory() as d:
+        root = pathlib.Path(d)
+        for filename in files:
+            target = root / filename
+            target.parent.mkdir(parents=True, exist_ok=True)
+            # Consume up to ~4 KiB of random bytes for each manifest file.
+            payload = fdp.ConsumeBytes(4096)
+            try:
+                target.write_bytes(payload)
+            except OSError:
+                return
+
+        fn = getattr(audit, fn_name)
+        try:
+            fn(str(root))
+        except Exception as exc:
+            # Any unhandled exception is a bug. Atheris will minimise the input
+            # and report the reproducer.
+            raise AssertionError(
+                f"{fn_name} raised on adversarial input: {type(exc).__name__}: {exc}"
+            ) from exc
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzz/requirements.in
+++ b/fuzz/requirements.in
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+#
+# SPDX-License-Identifier: MIT
+#
+# Source for fuzz/requirements.txt.
+# Regenerate the hashed lockfile with:
+#   pip-compile --generate-hashes --output-file=fuzz/requirements.txt fuzz/requirements.in
+#
+atheris==2.3.0

--- a/fuzz/requirements.txt
+++ b/fuzz/requirements.txt
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+#
+# SPDX-License-Identifier: MIT
+#
+# Hash-pinned dependencies for the Atheris fuzz harnesses.
+# Regenerate with:
+#   pip-compile --generate-hashes --output-file=fuzz/requirements.txt fuzz/requirements.in
+#
+atheris==2.3.0 \
+    --hash=sha256:005bde4b5a70e998b7fa097e9aa195972dcc2e04092156a0149cff7aa0de970e \
+    --hash=sha256:6d4e83c8a518e7f7d1c82ee52453255bf6309b7b335657534e83747d4fdfa110 \
+    --hash=sha256:9877b6c2bd5386f9fbbb2989a939c717383d9639f5476411c06fe50fe2fe09a6 \
+    --hash=sha256:b91cb296d60915c3efa4f6db48f09c4678b574cddb7ca98035f1cb9d9fb96f64 \
+    --hash=sha256:c353952ee375bf851527e8b2ea57fdefd7ad16aadfe18143801998075485eccd \
+    --hash=sha256:cf1fdf5fa220a41a2f262b32363fc566549502b2cb0addf4e1baad5531c0e825 \
+    --hash=sha256:e4e43d1ee4760916a84ff73c9c6cf9ac6eee80fc030479bbed43fe0b8e994981

--- a/skills/harden-packages/SKILL.md
+++ b/skills/harden-packages/SKILL.md
@@ -708,13 +708,15 @@ Use this section only if `audit.py` cannot be run. It replicates what the script
 
 ### Fuzzing
 
-- Is there a fuzzing integration appropriate to the language? Flag absence as ❌ (Scorecard scores 0 for `Fuzzing` without one).
-  - **Python**: `hypothesis` in `[dependency-groups].dev` + at least one `@given(...)` test. Property-based tests count.
+- Is there a fuzzing integration appropriate to the language? Flag absence as ❌ (Scorecard scores 0 for `Fuzzing` without one). **Important**: Scorecard's recognition is narrow and language-specific; do not assume a property-based test suite counts.
+  - **Python**: `import atheris` somewhere in the repo. Hypothesis is **not** recognised by Scorecard for Python (unlike for Erlang / Haskell / Elixir / Gleam, where property-based testing is recognised). Add an Atheris harness alongside the Hypothesis suite — they catch different bug classes (Hypothesis = blind property; Atheris = coverage-guided libFuzzer). Pin Atheris in a hash-verified `fuzz/requirements.txt` (it can't go in the main dev group because wheels only ship for Linux x86_64 + Python ≤ 3.11).
   - **Go**: `func FuzzXxx(f *testing.F)` targets, run as part of CI.
   - **Rust**: `cargo-fuzz` targets in `fuzz/`.
-  - **C/C++**: ClusterFuzzLite or OSS-Fuzz.
+  - **C/C++**: ClusterFuzzLite (`.clusterfuzzlite/Dockerfile`) or OSS-Fuzz (project listed in <https://github.com/google/oss-fuzz/tree/master/projects>).
+  - **Cross-language alternative**: `.clusterfuzzlite/Dockerfile` is recognised regardless of language and gives you actual continuous fuzzing infrastructure. Heavier setup but more value.
 - For parser-style code (anything consuming external file content, network input, user-controlled strings), the contract under test should be "parser must not crash on arbitrary input." Confirm tests cover the actual parsing surface, not trivial functions.
-- Is the fuzzing dependency hash-verified via the lockfile? `hypothesis` should be in `pyproject.toml [dependency-groups].dev` and locked in `uv.lock`, never installed inline.
+- Recommend running fuzz harnesses on a schedule (weekly is fine) rather than per-PR — coverage-guided fuzzing wants minutes-to-hours of runtime per harness, which is too slow for the critical PR path.
+- Reference: <https://github.com/ossf/scorecard/blob/main/docs/checks.md#fuzzing>.
 
 ### Interpreting Scorecard findings
 


### PR DESCRIPTION
## Root cause

Scorecard's `Fuzzing` check reported **score 0, "project is not fuzzed"** despite our Hypothesis property suite. Source: <https://github.com/ossf/scorecard/blob/v5.5.0/checks/raw/fuzzing.go>

```go
clients.Python: {
    filePatterns: []string{"*.py"},
    funcPattern:  `import atheris`,   // ← Hypothesis is NOT recognised
    Name:         fuzzers.PythonAtheris,
}
```

Hypothesis IS recognised for Erlang, Haskell, Elixir, and Gleam — just not Python. Our docs / SKILL / AGENTS files all incorrectly claimed it was. **Both bugs fixed in this PR.**

Verified locally:

```text
$ scorecard --local . --checks=Fuzzing
{"score":10,"reason":"project is fuzzed","name":"Fuzzing"}
```

## What's added

| File | What |
|---|---|
| `fuzz/fuzz_audit_parsers.py` | Atheris harness rotating through all 11 audit functions. Each call: random bytes → file the function expects → assert no unhandled exception |
| `fuzz/fuzz_audit_helpers.py` | Atheris harness for the parsing helpers (`grep`, `find_value`, `is_gitignored`, `detect_ecosystems`) — the ReDoS / encoding blast-radius surfaces |
| `fuzz/requirements.txt` + `.in` | `atheris==2.3.0` with full SHA-256 hashes (`pip-compile --generate-hashes`). **Not** in `pyproject.toml` dev group: Atheris wheels only ship for Linux x86_64 + Python ≤ 3.11 and would break local installs on macOS / 3.12 |
| `fuzz/README.md` | Why two suites, how to run locally, how to reproduce a crash, how to add new harnesses |
| `.github/workflows/fuzz.yml` | Scheduled Mon 07:17 UTC + `workflow_dispatch` (with `duration` input). Pinned to `ubuntu-24.04` + Python 3.11. Each harness gets 3 minutes of fuzz time. Crashes upload as artifacts and fail the run. `permissions: contents:read` only. Harden-Runner block-mode allowlist for github.com / api.github.com / objects.githubusercontent.com / release-assets.githubusercontent.com / files.pythonhosted.org / pypi.org. Duration input env-var-indirected and validated against `^[0-9]+$` (zizmor clean) |
| `.github/dependabot.yml` | New `pip` ecosystem entry for `/fuzz` so Atheris bumps appear as PRs |

## Documentation corrections

| File | What changed |
|---|---|
| `docs/github-actions.md` | Rewrote the Fuzzing section. New table enumerates exactly which patterns Scorecard recognises per language (Python: `atheris` ONLY). Full Atheris harness + workflow YAML examples. Wheel-availability constraint documented. New "when Hypothesis-only is acceptable" subsection for repos without parser surface |
| `skills/harden-packages/SKILL.md` | Rewrote the Fuzzing audit checklist. Explicit warning that Hypothesis does not satisfy Scorecard for Python despite doing so for other languages. Recommends Atheris + Hypothesis together, with ClusterFuzzLite as cross-language fallback |
| `agents/AGENTS-github-actions.md` | Rewrote required Fuzzing rules. "Must not remove" list now covers the Atheris harness specifically |
| `SECURITY.md` | "Security posture" fuzzing bullet split into property-based (Hypothesis, every PR) and coverage-guided (Atheris, weekly + satisfies Scorecard) |
| `CHANGELOG.md` | `[Unreleased]` entries under Added and Fixed |

## Hypothesis vs. Atheris (kept both)

| | Hypothesis | Atheris |
|---|---|---|
| Style | Blind property-based | Coverage-guided libFuzzer |
| Runs on | Every PR | Weekly schedule |
| Speed | Fast (200 examples per parser) | Slow (3 min of mutations per harness) |
| Bug class | Contract violations, declarative invariants | Deep parser crashes, ReDoS, encoding edges |
| Scorecard recognised? | ❌ for Python | ✅ |

## Verification

- `zizmor` clean (1 high-severity template-injection finding caught + fixed via env-var indirection)
- `pytest` 217/217
- `reuse lint` 64/64
- `markdownlint-cli2` 32 files / 0 errors
- `scorecard --local . --checks=Fuzzing` → **10/10**

🤖 Generated with [pi](https://github.com/badlogic/lemmy/tree/main/apps/pi)
