### PR TITLE
ci(scorecard): add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,6 +17,7 @@ on:
     - cron: "37 5 * * 1"  # weekly, Monday 05:37 UTC
   push:
     branches: [main]
+  workflow_dispatch:  # allow manual `gh workflow run scorecard.yml`
 
 permissions: {}
 


### PR DESCRIPTION
Allows manual `gh workflow run scorecard.yml` on demand. Without this, manual dispatch errors with HTTP 422. No change to existing triggers.

🤖 Generated with [pi](https://github.com/badlogic/lemmy/tree/main/apps/pi)