### PR TITLE
docs(fuzz): document corpus binary inputs (OSPS-QA-05.02)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- [`fuzz/corpus/fuzz_audit_helpers/README.md`](fuzz/corpus/fuzz_audit_helpers/README.md) documenting every binary input in the corpus (currently one: `crash-find_value-no-group`, 4 bytes). Records hex bytes, base64, the bug each input triggered, the fix, and the unit-test regression that pins the same bytes in source. Satisfies OpenSSF Baseline `OSPS-QA-05.02` ("no unreviewable binary artifacts") for the corpus directory — the files have to stay raw bytes on disk for libFuzzer to replay them, but every byte is now documented and cross-referenced.
+- `fuzz/README.md`: pointer to the per-harness corpus READMEs and the requirement to document every new corpus entry with hex bytes + bug + fix + regression test.
+
 ### Changed
 
 - Branch protection on `main` tightened to maximise Scorecard's `Branch-Protection` check score on a solo project:

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -58,4 +58,4 @@ The scheduled workflow [`.github/workflows/fuzz.yml`](../.github/workflows/fuzz.
 
 Every crash is a bug. The audit functions' contract is "must not raise on any input from a target repository's filesystem". If the input is something the audit function should reject explicitly (e.g. binary garbage in a YAML file), the function should detect and skip it cleanly, not crash.
 
-Fix the underlying defensive-parsing bug in `audit.py`, then add the crash input to the corpus (`fuzz/corpus/<harness>/`) so it's regression-tested forever.
+Fix the underlying defensive-parsing bug in `audit.py`, then add the crash input to the corpus (`fuzz/corpus/<harness>/`) so it's regression-tested forever. Document the new corpus file in the per-harness corpus README (e.g. [`fuzz/corpus/fuzz_audit_helpers/README.md`](corpus/fuzz_audit_helpers/README.md)) with hex bytes, the bug it triggered, the fix, and the unit-test regression — this keeps the binary input reviewable per OpenSSF Baseline `OSPS-QA-05.02`.

--- a/fuzz/corpus/fuzz_audit_helpers/README.md
+++ b/fuzz/corpus/fuzz_audit_helpers/README.md
@@ -1,0 +1,41 @@
+<!--
+SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+SPDX-License-Identifier: MIT
+-->
+
+# Fuzz corpus — `fuzz_audit_helpers`
+
+Persistent corpus inputs for the [`fuzz/fuzz_audit_helpers.py`](../../fuzz_audit_helpers.py) Atheris harness. libFuzzer replays every file here at the start of each fuzz run, so any past crash becomes a permanent regression test even if the underlying bug is fixed.
+
+Files in this directory **must remain raw bytes on disk** — libFuzzer reads them with `read(2)`, not as text. To keep them reviewable (per OpenSSF Baseline `OSPS-QA-05.02`, "no unreviewable binary artifacts"), every file is documented below with its exact byte sequence, the bug it triggered, and the unit-test regression that pins the same input.
+
+## `crash-find_value-no-group`
+
+| | |
+|---|---|
+| Size | 4 bytes |
+| Hex | `00 8b 00 89` |
+| Base64 | `AIsAiQ==` |
+| Found by | Atheris, first scheduled run of `.github/workflows/fuzz.yml`, iteration #16 (~1s of fuzz time) |
+| Bug | `audit.find_value()` raised `IndexError: no such group` when the regex pattern matched but had no capture group |
+| Fix | [`skills/harden-packages/audit.py`](../../../skills/harden-packages/audit.py) — `find_value()` now returns `None` if `m.groups()` is empty |
+| Regression test | [`tests/test_helpers.py::test_find_value_pattern_without_capture_group`](../../../tests/test_helpers.py) — pins the exact 4 bytes in source |
+| Reachability from production callers | None: every internal call site in `audit.py` uses a pattern with `(...)`. Defensive fix to align the function with its documented contract ("return None on no match") |
+
+Reproduce locally (Linux, Python 3.11):
+
+```bash
+pip install -r fuzz/requirements.txt
+python fuzz/fuzz_audit_helpers.py fuzz/corpus/fuzz_audit_helpers/crash-find_value-no-group
+# Expected: clean exit (the bug is fixed). Pre-fix: IndexError: no such group.
+```
+
+## Adding a new corpus entry
+
+When a future fuzz run finds a crash:
+
+1. Fix the bug in `skills/harden-packages/audit.py`.
+2. Add a unit-test regression in `tests/test_helpers.py` (or the relevant `tests/test_audit_*.py`) that pins the exact input bytes in source.
+3. Move the Atheris artifact (`fuzz-artifacts/crash-*`) into this directory with a descriptive name.
+4. Add a section to this README following the same template as above (size, hex, base64, found-by, bug, fix, regression test, reachability).


### PR DESCRIPTION
OpenSSF Baseline `OSPS-QA-05.02` prohibits unreviewable binary artifacts. The Atheris corpus contains binary inputs (currently one 4-byte file) that must stay raw bytes on disk for libFuzzer to replay them.

Mitigation: per-harness corpus README documenting every input — hex, base64, found-by metadata, the bug it triggered, the fix, and the unit-test regression that pins the same bytes in source.

Now `fuzz/corpus/fuzz_audit_helpers/crash-find_value-no-group` is unambiguously reviewable: `README.md` next to it shows the exact 4 bytes (`00 8b 00 89`), points at the test that pins them, and links to the audit.py fix. `fuzz/README.md` updated with the rule that every new corpus entry must be documented the same way before commit.

ð¤ Generated with [pi](https://github.com/badlogic/lemmy/tree/main/apps/pi)