### PR TITLE
docs: add OpenSSF Baseline badge to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- OpenSSF Open Source Project Security (OSPS) Baseline badge added to the README. Self-assessment completed at <https://www.bestpractices.dev/projects/12822>: 23 controls Met, 2 N/A, 0 Unmet across the AC / BR / DO / GV / LE / QA / VM domains. The Baseline self-assessment is independent of the Best Practices Passing badge already held; both link to the same project (12822).
+
+### Added
+
 - [`fuzz/corpus/fuzz_audit_helpers/README.md`](fuzz/corpus/fuzz_audit_helpers/README.md) documenting every binary input in the corpus (currently one: `crash-find_value-no-group`, 4 bytes). Records hex bytes, base64, the bug each input triggered, the fix, and the unit-test regression that pins the same bytes in source. Satisfies OpenSSF Baseline `OSPS-QA-05.02` ("no unreviewable binary artifacts") for the corpus directory — the files have to stay raw bytes on disk for libFuzzer to replay them, but every byte is now documented and cross-referenced.
 - `fuzz/README.md`: pointer to the per-harness corpus READMEs and the requirement to document every new corpus entry with hex bytes + bug + fix + regression test.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ SPDX-License-Identifier: MIT
 
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/jordanconway/package-manager-hardening/badge)](https://scorecard.dev/viewer/?uri=github.com/jordanconway/package-manager-hardening)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12822/badge)](https://www.bestpractices.dev/projects/12822)
+[![OpenSSF Baseline](https://www.bestpractices.dev/projects/12822/baseline)](https://www.bestpractices.dev/projects/12822)
 [![REUSE status](https://api.reuse.software/badge/github.com/jordanconway/package-manager-hardening)](https://api.reuse.software/info/github.com/jordanconway/package-manager-hardening)
 
 A reference for hardening software supply chains across npm, pnpm, Yarn, Bun, pip, uv, Go modules, Cargo, Maven, Gradle, Terraform, and OpenTofu.


### PR DESCRIPTION
Self-assessment completed at <https://www.bestpractices.dev/projects/12822> — 23 Met, 2 N/A, 0 Unmet across the AC / BR / DO / GV / LE / QA / VM domains.

Independent of the Best Practices Passing badge already held; both link to project 12822.

ð¤ Generated with [pi](https://github.com/badlogic/lemmy/tree/main/apps/pi)