### PR TITLE
chore: replace stray literal unicode escape in fuzz docstring

### DIFF
--- a/fuzz/fuzz_audit_parsers.py
+++ b/fuzz/fuzz_audit_parsers.py
@@ -16,7 +16,7 @@ Each ecosystem audit function consumes one or more manifest / lockfile / workflo
 files in a directory. The harness writes random bytes to the file the audit
 function expects, runs the function, and asserts no unhandled exception is
 raised. Atheris's libFuzzer instrumentation evolves inputs toward unexplored
-branches \u2014 catches a different class of bug than the property-based suite in
+branches -- catches a different class of bug than the property-based suite in
 tests/test_fuzz.py (which is *not* recognised by OpenSSF Scorecard's Fuzzing
 check).
 """


### PR DESCRIPTION
Fix the one literal `\u2014` escape that leaked into a tracked file (`fuzz/fuzz_audit_parsers.py` docstring), and decode the same escapes in PR bodies #28 / #29 / #30 / #31.

Cause: passing strings with em-dashes through `git commit -m "..."` and `gh pr create --body "..."` in bash mangles UTF-8 to literal `\uXXXX`. Going forward, em-dashes only get used in files written via the `write` tool, never in shell-passed strings; ASCII `--` is used in commits / PR bodies.

Audit:

- Tracked files: only `fuzz/fuzz_audit_parsers.py` was affected (one docstring line). Now uses `--`.
- Merged commit messages: also affected, but immutable on a protected branch (would require force-push). Left as-is.
- Release notes (`v0.1.0`): clean.
- PR bodies (#28 #29 #30 #31): edited via `gh pr edit --body-file` to replace the literal `\u2014` etc. with the real characters.

Verification: `git ls-files | xargs grep -E '\\u[0-9a-fA-F]{4}'` returns no matches outside `package-lock.json` / `uv.lock` / `fuzz/corpus/` (where they're legitimate JSON / binary content).

🤖 Generated with [pi](https://github.com/badlogic/lemmy/tree/main/apps/pi)
