### PR TITLE
ci: expand Python test matrix to 3.10–3.14 and bound requires-python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 name = "package-manager-hardening"
 version = "0.0.0"
 description = "Package manager hardening skill and tests"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## What changed

- **`.github/workflows/ci.yml`** — added Python 3.11, 3.13, and 3.14 to the `python-test` matrix (was `["3.10", "3.12"]`, now `["3.10", "3.11", "3.12", "3.13", "3.14"]`)
- **`pyproject.toml`** — tightened `requires-python` from the open-ended `>=3.10` to `>=3.10,<3.15`

## Why

`requires-python = ">=3.10"` claimed support for every future Python version, but only 3.10 and 3.12 were actually tested. That gap meant regressions on 3.11, 3.13, or 3.14 would go undetected in CI.

All five versions in the new matrix are active, non-EOL releases:

| Version | Status | EOL |
|---------|--------|-----|
| 3.10 | Security-only | Oct 2026 |
| 3.11 | Security-only | Oct 2027 |
| 3.12 | Security-only | Oct 2028 |
| 3.13 | Bugfix | Oct 2029 |
| 3.14 | Bugfix | Oct 2030 |

Python 3.14 is confirmed stable at 3.14.5. Python 3.16 is pre-release and excluded.

The bounded `<3.15` prevents silent installation on untested pre-release versions. The upper bound should be bumped when the next stable Python is added to the matrix and tested.

## Reviewer notes

- No `uv.lock` changes needed — dev dependencies (ruff, pytest, hypothesis) are pure Python and compatible across all five versions; `uv sync --frozen --group dev --python "$PYTHON_VERSION"` handles per-leg resolution dynamically.
- The `fuzz.yml` workflow stays on 3.11 (Atheris wheel constraint) — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)