### PR TITLE
feat(skill): add verify_hash.py helper and 'never fabricate hashes' guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ __pycache__/
 
 # Node.js
 node_modules/
+
+# Local agent / editor config (Claude Code, etc.)
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- New companion script [`skills/harden-packages/verify_hash.py`](skills/harden-packages/verify_hash.py): a single-file, dependency-free CLI that resolves cryptographic hashes from authoritative upstream sources so AI agents using the skill never have to fabricate them. Subcommands cover every ecosystem the skill audits: `gh-action`, `git-ref`, `oci`, `pypi`, `npm`, `crate`, `gem`, `packagist`, `gradle-dist`, `maven`, `tf-provider`, `go-module`. Default output is a bare hash on stdout (shell-friendly); `--json` adds metadata. Exit codes: `0` success, `1` upstream lookup failed, `2` usage error, `3` required external tool missing. Tested with 35 unit tests in [`tests/test_verify_hash.py`](tests/test_verify_hash.py) — all upstream calls are mocked so the suite stays offline.
+- New `## Hash Verification: Never Fabricate` section in every `agents/AGENTS-*.md` file (11 files: docker, github-actions, go, helm, jvm, nodejs, php, python, ruby, rust, terraform). Each section states the rule (never invent / guess / autocomplete a hash), points at `verify_hash.py` as the preferred verification path when the `harden-packages` skill is loaded, and lists a short ecosystem-specific manual fallback for repos that adopt only the AGENTS file. Closes the gap where prior guidance assumed lockfile-generated hashes but said nothing about ad-hoc SHA / digest pinning (`actions/checkout@<sha>`, `FROM node:20@sha256:...`, `go install pkg@<sha>`, etc.).
+- New `## Companion tool: verify_hash.py` section in [`skills/harden-packages/SKILL.md`](skills/harden-packages/SKILL.md) so an agent loading the skill discovers the helper alongside `audit.py` without having to read the AGENTS files first.
+
+### Added
+
 - OpenSSF Open Source Project Security (OSPS) Baseline badge added to the README. Self-assessment completed at <https://www.bestpractices.dev/projects/12822>: 23 controls Met, 2 N/A, 0 Unmet across the AC / BR / DO / GV / LE / QA / VM domains. The Baseline self-assessment is independent of the Best Practices Passing badge already held; both link to the same project (12822).
 
 ### Added

--- a/agents/AGENTS-docker.md
+++ b/agents/AGENTS-docker.md
@@ -8,6 +8,22 @@ SPDX-License-Identifier: MIT
 
 This file contains mandatory guidelines for working with Dockerfiles and container images in this project. Follow these rules whenever modifying Dockerfiles, updating base images, or adding container-related CI steps.
 
+## Hash Verification: Never Fabricate
+
+**AI agents must never invent, guess, autocomplete, or extrapolate an image digest (`sha256:...`) or any other cryptographic hash.** A fabricated digest either fails the pull (best case) or silently pins to an unintended image if it collides with anything in the registry. Treat any digest you did not just look up as unknown.
+
+Every `@sha256:...` written into a Dockerfile, Compose file, Kubernetes manifest, or CI step must come from an authoritative registry lookup performed in this session.
+
+**Preferred:** if the `harden-packages` skill is available, use its helper:
+
+```bash
+python {SKILL_DIR}/verify_hash.py oci <image>:<tag>          # → sha256: digest
+```
+
+**Fallback if the helper isn't present:** `crane digest <image>:<tag>`, `skopeo inspect docker://<image>:<tag> --format '{{.Digest}}'`, or `docker buildx imagetools inspect <image>:<tag> --format '{{json .Manifest}}' | jq -r .digest`.
+
+If you cannot verify a digest with any of the above, **stop and ask the user**. Do not insert a placeholder, a truncated digest, or a "likely correct" value.
+
 ## Base Image Rules
 
 **Always pin base images to their immutable digest.** Never use a mutable tag alone:

--- a/agents/AGENTS-github-actions.md
+++ b/agents/AGENTS-github-actions.md
@@ -8,6 +8,25 @@ SPDX-License-Identifier: MIT
 
 This file contains mandatory guidelines for working with GitHub Actions workflows in this repository. Follow these rules whenever adding, modifying, or reviewing files under `.github/workflows/`.
 
+## Hash Verification: Never Fabricate
+
+**AI agents must never invent, guess, autocomplete, or extrapolate a commit SHA, image digest, or any other cryptographic hash.** A fabricated SHA either fails verification (breaks the build) or — worse — silently pins to whatever artifact happens to collide with the guessed value. Treat any hash you did not just look up as unknown.
+
+Every action SHA, runner image digest, or tool integrity hash written into a workflow must come from an authoritative lookup performed in this session.
+
+**Preferred:** if the `harden-packages` skill is available, use its helper instead of hand-rolling `curl`/`gh` invocations:
+
+```bash
+python {SKILL_DIR}/verify_hash.py gh-action <owner>/<repo> <tag-or-ref>   # → full commit SHA
+python {SKILL_DIR}/verify_hash.py oci <image>:<tag>                       # → sha256: digest
+```
+
+**Fallback if the helper isn't present:** `gh api repos/<owner>/<repo>/commits/<ref> --jq .sha` or `git ls-remote https://github.com/<owner>/<repo>.git 'refs/tags/<tag>^{}'`.
+
+For tool hashes inside workflows, generate them with the ecosystem's own tooling (`npm ci` against a committed `package-lock.json`, `pip-compile --generate-hashes`, etc.) — never hand-edit `integrity:` or `--hash=` values.
+
+If you cannot verify a hash with any of the above, **stop and ask the user**. Do not insert a placeholder, a truncated SHA, or a "likely correct" value.
+
 ## Checkout: disable credential persistence
 
 Every `actions/checkout` invocation must set `persist-credentials: false` unless the job genuinely needs to push back to the repo (release tagging, automated commits). The default leaves `GITHUB_TOKEN` in `.git/config` for the rest of the job, where any subsequent step — including a compromised dependency build — can use it.

--- a/agents/AGENTS-go.md
+++ b/agents/AGENTS-go.md
@@ -8,6 +8,25 @@ SPDX-License-Identifier: MIT
 
 This file contains mandatory guidelines for managing dependencies in this Go module project. Follow these rules whenever adding, updating, or removing modules, or modifying CI configuration.
 
+## Hash Verification: Never Fabricate
+
+**AI agents must never invent, guess, autocomplete, or extrapolate a `go.sum` hash, module pseudo-version, or commit SHA.** A fabricated hash will fail `go mod verify` (best case) or silently pin to the wrong artifact if it accidentally matches.
+
+All `go.sum` entries must be produced by the Go toolchain itself — run `go mod tidy` / `go get <module>@<version>` and commit the resulting files. Do not hand-edit `go.sum`.
+
+When pinning a `go install` invocation or a `replace` directive to a commit, resolve the SHA / module hash from an authoritative source.
+
+**Preferred:** if the `harden-packages` skill is available, use its helper:
+
+```bash
+python {SKILL_DIR}/verify_hash.py gh-action <owner>/<repo> <tag-or-ref>   # → commit SHA
+python {SKILL_DIR}/verify_hash.py go-module <module> <version>           # → h1: hash via proxy.golang.org
+```
+
+**Fallback:** `gh api repos/<owner>/<repo>/commits/<ref> --jq .sha`, `git ls-remote https://github.com/<owner>/<repo>.git refs/tags/<tag>`, or `GOFLAGS=-mod=mod go list -m <module>@<sha>` to let the toolchain compute the pseudo-version.
+
+If you cannot verify a hash or SHA with any of the above, **stop and ask the user**. Do not insert a placeholder or a "likely correct" value.
+
 ## Dependency Rules
 
 **Always pin explicit versions.** Never use `@latest` or `@master` when adding or updating a module. Always specify a tagged version:

--- a/agents/AGENTS-helm.md
+++ b/agents/AGENTS-helm.md
@@ -8,6 +8,24 @@ SPDX-License-Identifier: MIT
 
 This file contains mandatory guidelines for managing Helm chart dependencies in this project. Follow these rules whenever adding, updating, or removing chart dependencies, or modifying CI configuration.
 
+## Hash Verification: Never Fabricate
+
+**AI agents must never invent, guess, autocomplete, or extrapolate a `Chart.lock` digest, an OCI image digest, or any other cryptographic hash.** A fabricated digest either fails verification or silently pins to the wrong artifact.
+
+All `Chart.lock` digests must be produced by Helm itself — run `helm dependency update` and commit the resulting `Chart.lock`. Do not hand-edit `digest:` fields.
+
+For OCI image digests referenced in `values.yaml`:
+
+**Preferred:** if the `harden-packages` skill is available, use its helper:
+
+```bash
+python {SKILL_DIR}/verify_hash.py oci <registry>/<image>:<tag>
+```
+
+**Fallback:** `crane digest <registry>/<image>:<tag>` or `docker buildx imagetools inspect <image>:<tag> --format '{{json .Manifest}}' | jq -r .digest`. For OCI-hosted charts, also `helm pull oci://<registry>/<chart> --version <ver>` and inspect the downloaded artifact.
+
+If you cannot verify a digest with any of the above, **stop and ask the user**. Do not insert a placeholder or a "likely correct" value.
+
 ## Dependency Rules
 
 **Always pin exact chart versions** in `Chart.yaml`. Never use `^`, `~`, `>=`, `x` wildcards, or bare major/minor strings:

--- a/agents/AGENTS-jvm.md
+++ b/agents/AGENTS-jvm.md
@@ -8,6 +8,23 @@ SPDX-License-Identifier: MIT
 
 This file contains mandatory guidelines for managing dependencies in this JVM project (Maven or Gradle). Follow these rules whenever adding, updating, or removing dependencies or plugins, or modifying CI configuration.
 
+## Hash Verification: Never Fabricate
+
+**AI agents must never invent, guess, autocomplete, or extrapolate a checksum** — including Gradle's `distributionSha256Sum`, entries in `verification-metadata.xml`, Maven's `.sha1` / `.sha256` / `.sha512` sibling files, or any other cryptographic hash. A fabricated checksum either fails verification or silently pins to the wrong artifact.
+
+All JVM dependency / wrapper checksums must come from an authoritative source.
+
+**Preferred:** if the `harden-packages` skill is available, use its helper:
+
+```bash
+python {SKILL_DIR}/verify_hash.py gradle-dist <version> [bin|all]   # Gradle wrapper SHA256
+python {SKILL_DIR}/verify_hash.py maven <group>:<artifact>:<version>  # Maven Central SHA256/SHA1
+```
+
+**Fallback:** `curl -fsSL https://services.gradle.org/distributions/gradle-<ver>-bin.zip.sha256` for the wrapper, `curl -fsSL https://repo1.maven.org/maven2/<path>/<artifact>-<ver>.jar.sha256` for Maven Central, or `./gradlew --write-verification-metadata sha256 help` to let Gradle generate dependency verification metadata.
+
+If you cannot verify a checksum with any of the above, **stop and ask the user**. Do not insert a placeholder or a "likely correct" value.
+
 ## Dependency Rules — All JVM projects
 
 **Always pin exact versions** for both direct dependencies and plugins. Never use dynamic versions, ranges, `LATEST`, `RELEASE`, `+`, or `SNAPSHOT` in production manifests.

--- a/agents/AGENTS-nodejs.md
+++ b/agents/AGENTS-nodejs.md
@@ -8,6 +8,24 @@ SPDX-License-Identifier: MIT
 
 This file contains mandatory guidelines for managing dependencies in this Node.js project. Follow these rules whenever adding, updating, or removing packages, or modifying CI configuration.
 
+## Hash Verification: Never Fabricate
+
+**AI agents must never invent, guess, autocomplete, or extrapolate an SRI `integrity` value (`sha512-...`), a tarball checksum, or any other cryptographic hash** in `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `bun.lockb`, or `.npmrc`. A fabricated integrity hash either fails verification or silently pins to the wrong tarball.
+
+All lockfile integrity hashes must be produced by the package manager itself — run `npm install`, `pnpm install`, `yarn install`, or `bun install` and commit the resulting lockfile. Do not hand-edit `integrity:` fields.
+
+To confirm a published tarball's integrity (e.g. when reviewing a Dependabot PR):
+
+**Preferred:** if the `harden-packages` skill is available, use its helper:
+
+```bash
+python {SKILL_DIR}/verify_hash.py npm <package> <version>    # → sha512-... SRI integrity
+```
+
+**Fallback:** `npm view <pkg>@<version> dist.integrity dist.tarball dist.shasum`.
+
+If you cannot verify a hash with any of the above, **stop and ask the user**. Do not insert a placeholder or a "likely correct" value.
+
 ## Package Manager
 
 This project uses: <!-- npm | pnpm | yarn | bun — delete as appropriate -->

--- a/agents/AGENTS-php.md
+++ b/agents/AGENTS-php.md
@@ -8,6 +8,25 @@ SPDX-License-Identifier: MIT
 
 This file contains mandatory guidelines for managing dependencies in this PHP project. Follow these rules whenever adding, updating, or removing packages, or modifying CI configuration.
 
+## Hash Verification: Never Fabricate
+
+**AI agents must never invent, guess, autocomplete, or extrapolate a `composer.lock` content-hash, package `dist.shasum`, `reference` commit SHA, or any other cryptographic hash.** A fabricated hash either fails verification or silently pins to the wrong artifact.
+
+All `composer.lock` hashes must be produced by Composer itself — run `composer update <pkg>` / `composer install` and commit the resulting `composer.lock`. Do not hand-edit `shasum`, `reference`, or `content-hash` fields.
+
+To confirm a package version is real:
+
+**Preferred:** if the `harden-packages` skill is available, use its helper:
+
+```bash
+python {SKILL_DIR}/verify_hash.py packagist <vendor>/<pkg> <version>   # → dist.shasum / source.reference
+python {SKILL_DIR}/verify_hash.py gh-action <owner>/<repo> <ref>       # for git-sourced packages
+```
+
+**Fallback:** `composer show <vendor>/<pkg> <version> --all` or `curl -fsSL https://repo.packagist.org/p2/<vendor>/<pkg>.json | jq '...'`.
+
+If you cannot verify a hash with any of the above, **stop and ask the user**. Do not insert a placeholder or a "likely correct" value.
+
 ## Dependency Rules
 
 **Always pin exact versions** in `composer.json`. Never use `^`, `~`, `>=`, or wildcard constraints for production dependencies:

--- a/agents/AGENTS-python.md
+++ b/agents/AGENTS-python.md
@@ -8,6 +8,26 @@ SPDX-License-Identifier: MIT
 
 This file contains mandatory guidelines for managing dependencies in this Python project. Follow these rules whenever adding, updating, or removing packages, or modifying CI configuration.
 
+## Hash Verification: Never Fabricate
+
+**AI agents must never invent, guess, autocomplete, or extrapolate a `--hash=sha256:...` value, a `uv.lock` hash, a `poetry.lock` hash, or any other cryptographic hash.** A fabricated hash either fails `pip install --require-hashes` (best case) or silently pins to the wrong wheel/sdist if it accidentally matches.
+
+All Python dependency hashes must be produced by the resolver itself — run `pip-compile --generate-hashes`, `uv lock`, `uv pip compile --generate-hashes`, or `poetry lock` and commit the resulting lockfile. Do not hand-edit `--hash=` lines or `hashes:` blocks.
+
+To confirm a specific artifact's hash:
+
+**Preferred:** if the `harden-packages` skill is available, use its helper:
+
+```bash
+python {SKILL_DIR}/verify_hash.py pypi <pkg> <version>            # all artifacts
+python {SKILL_DIR}/verify_hash.py pypi <pkg> <version> --wheel    # wheels only
+python {SKILL_DIR}/verify_hash.py pypi <pkg> <version> --sdist    # sdist only
+```
+
+**Fallback:** `curl -fsSL https://pypi.org/pypi/<pkg>/<version>/json | jq -r '.urls[] | "\(.digests.sha256)  \(.filename)"'`.
+
+If you cannot verify a hash with any of the above, **stop and ask the user**. Do not insert a placeholder or a "likely correct" value.
+
 ## Package Manager
 
 This project uses: <!-- uv | pip+pip-tools — delete as appropriate -->

--- a/agents/AGENTS-ruby.md
+++ b/agents/AGENTS-ruby.md
@@ -8,6 +8,25 @@ SPDX-License-Identifier: MIT
 
 This file contains mandatory guidelines for managing dependencies in this Ruby project. Follow these rules whenever adding, updating, or removing gems, or modifying CI configuration.
 
+## Hash Verification: Never Fabricate
+
+**AI agents must never invent, guess, autocomplete, or extrapolate a `Gemfile.lock` checksum, `bundler-checksums` entry, gem `.gem` SHA256, or commit SHA for a git-sourced gem.** A fabricated hash either fails verification or silently pins to the wrong artifact.
+
+All `Gemfile.lock` entries (and any `Gemfile.lock.checksums` produced by the `bundler-checksums` plugin) must be produced by Bundler itself — run `bundle install` / `bundle update <gem>` and commit the result. Do not hand-edit checksum or `revision:` fields.
+
+To confirm a published gem's checksum or a git revision:
+
+**Preferred:** if the `harden-packages` skill is available, use its helper:
+
+```bash
+python {SKILL_DIR}/verify_hash.py gem <gem> <version>             # → SHA256
+python {SKILL_DIR}/verify_hash.py gh-action <owner>/<repo> <ref>  # for git-sourced gems
+```
+
+**Fallback:** `curl -fsSL https://rubygems.org/api/v2/rubygems/<gem>/versions/<version>.json | jq '{sha, number, platform}'`.
+
+If you cannot verify a hash with any of the above, **stop and ask the user**. Do not insert a placeholder or a "likely correct" value.
+
 ## Dependency Rules
 
 **Always pin exact versions** in `Gemfile`. Never use `~>`, `>=`, or open range constraints for production dependencies:

--- a/agents/AGENTS-rust.md
+++ b/agents/AGENTS-rust.md
@@ -8,6 +8,25 @@ SPDX-License-Identifier: MIT
 
 This file contains mandatory guidelines for managing dependencies in this Rust project. Follow these rules whenever adding, updating, or removing crates, or modifying CI configuration.
 
+## Hash Verification: Never Fabricate
+
+**AI agents must never invent, guess, autocomplete, or extrapolate a `Cargo.lock` checksum, a `[source.<name>] replace-with` SHA, a `cargo-vet` audit hash, or a git `rev = "..."` commit SHA.** A fabricated hash either fails verification or silently pins to the wrong artifact.
+
+All `Cargo.lock` checksums must be produced by Cargo itself — run `cargo update -p <crate>` / `cargo generate-lockfile` and commit the result. Do not hand-edit `checksum = "..."` lines.
+
+To confirm a published crate's checksum or a git commit:
+
+**Preferred:** if the `harden-packages` skill is available, use its helper:
+
+```bash
+python {SKILL_DIR}/verify_hash.py crate <crate> <version>         # → SHA256
+python {SKILL_DIR}/verify_hash.py gh-action <owner>/<repo> <ref>  # for git-sourced crates
+```
+
+**Fallback:** `curl -fsSL https://crates.io/api/v1/crates/<crate>/<version> | jq '.version | {num, checksum, dl_path}'`.
+
+If you cannot verify a hash with any of the above, **stop and ask the user**. Do not insert a placeholder or a "likely correct" value.
+
 ## Dependency Rules
 
 **Always pin exact versions** using the `=` operator in `Cargo.toml`. Never use bare version strings, `>=`, or `~` ranges for production dependencies:

--- a/agents/AGENTS-terraform.md
+++ b/agents/AGENTS-terraform.md
@@ -11,6 +11,26 @@ This file contains mandatory guidelines for managing provider and module depende
 <!-- terraform | opentofu -->
 Delete the line above and keep only the tool that applies to this project.
 
+## Hash Verification: Never Fabricate
+
+**AI agents must never invent, guess, autocomplete, or extrapolate a `.terraform.lock.hcl` `h1:` or `zh:` hash, a module checksum, or any other cryptographic hash.** A fabricated hash either fails `terraform init` verification or silently allows the wrong provider binary to be installed.
+
+All `.terraform.lock.hcl` entries must be produced by the CLI itself — run `terraform providers lock -platform=...` (or `tofu providers lock`) for every CI/dev platform and commit the resulting file. Do not hand-edit `hashes = [...]` blocks.
+
+To confirm a provider version actually exists on the registry before pinning to it:
+
+**Preferred:** if the `harden-packages` skill is available, use its helper:
+
+```bash
+python {SKILL_DIR}/verify_hash.py tf-provider <namespace>/<name>              # list all versions
+python {SKILL_DIR}/verify_hash.py tf-provider <namespace>/<name> <version>   # verify exists
+python {SKILL_DIR}/verify_hash.py tf-provider <namespace>/<name> --opentofu  # OpenTofu registry
+```
+
+**Fallback:** `curl -fsSL https://registry.terraform.io/v1/providers/<namespace>/<name>/versions | jq '.versions[].version'` (or `registry.opentofu.org` for OpenTofu).
+
+If you cannot verify a hash with any of the above, **stop and ask the user**. Do not insert a placeholder or a "likely correct" value.
+
 ## Dependency Rules
 
 **Always pin providers to exact versions** using the `=` operator in `required_providers`. Never use `~>`, `>=`, or open ranges for production providers:

--- a/skills/harden-packages/SKILL.md
+++ b/skills/harden-packages/SKILL.md
@@ -45,6 +45,40 @@ the audit phase.
 the checklist in the [Reference: Manual Audit Checklist](#reference-manual-audit-checklist)
 section below.
 
+## Companion tool: `verify_hash.py`
+
+Any time hardening work requires writing a cryptographic hash, digest, or commit
+SHA into a file — pinning a GitHub Action, a container image, a Gradle wrapper, a
+lockfile, a Terraform provider — use `verify_hash.py` to resolve it from the
+authoritative upstream registry. **Never invent, guess, autocomplete, or
+extrapolate a hash.**
+
+```bash
+python {SKILL_DIR}/verify_hash.py --help    # list subcommands
+
+# Examples (each prints just the hash on stdout; add --json for metadata)
+python {SKILL_DIR}/verify_hash.py gh-action actions/checkout v4
+python {SKILL_DIR}/verify_hash.py oci node:20-alpine
+python {SKILL_DIR}/verify_hash.py pypi requests 2.32.3 --sdist
+python {SKILL_DIR}/verify_hash.py npm left-pad 1.3.0
+python {SKILL_DIR}/verify_hash.py crate serde 1.0.210
+python {SKILL_DIR}/verify_hash.py gem rails 7.2.1
+python {SKILL_DIR}/verify_hash.py packagist symfony/console 7.1.5
+python {SKILL_DIR}/verify_hash.py gradle-dist 8.10
+python {SKILL_DIR}/verify_hash.py maven org.apache.commons:commons-lang3:3.17.0
+python {SKILL_DIR}/verify_hash.py tf-provider hashicorp/aws 5.84.0
+python {SKILL_DIR}/verify_hash.py go-module github.com/stretchr/testify v1.9.0
+python {SKILL_DIR}/verify_hash.py git-ref https://gitlab.com/foo/bar.git v1.0.0
+```
+
+Exit codes: `0` success, `1` upstream lookup failed, `2` usage error, `3` required
+external tool missing (only for `oci` and `git-ref`, which shell out to
+`crane`/`skopeo`/`docker` or `git`). If a lookup fails or the right tool isn't
+available, stop and ask the user — do not write a placeholder.
+
+The per-ecosystem AGENTS files in `agents/` reference this helper as the preferred
+verification path and document a manual fallback for each ecosystem.
+
 ## Step 2: Interpret findings
 
 Read the JSON output. The top-level keys are:

--- a/skills/harden-packages/verify_hash.py
+++ b/skills/harden-packages/verify_hash.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+# SPDX-License-Identifier: MIT
+"""
+verify_hash.py — resolve and verify hashes / digests / SHAs from authoritative
+upstream sources so AI agents never have to fabricate them.
+
+Default output: a single line with just the hash, suitable for shell capture:
+
+    SHA=$(python verify_hash.py gh-action actions/checkout v4)
+
+With --json, prints a structured object with extra metadata.
+
+Exit codes:
+    0  success (hash printed)
+    1  upstream lookup failed (not found, version doesn't exist, network)
+    2  usage error
+    3  required external tool missing (only for subcommands that need one)
+
+No third-party Python dependencies. Uses urllib for HTTP and shells out only
+where there's no plain HTTP API (git, docker/crane/skopeo, go).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from typing import Any, NoReturn
+
+UA = "verify-hash/1.0 (+https://github.com/linuxfoundation/package-manager-hardening)"
+TIMEOUT = 20
+
+
+# ---------- helpers ----------------------------------------------------------
+
+def _die(msg: str, code: int = 1) -> NoReturn:
+    print(f"verify-hash: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def _http_json(url: str, headers: dict[str, str] | None = None) -> Any:
+    req = urllib.request.Request(url, headers={"User-Agent": UA, "Accept": "application/json", **(headers or {})})
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        _die(f"HTTP {e.code} from {url}")
+    except urllib.error.URLError as e:
+        _die(f"network error fetching {url}: {e.reason}")
+
+
+def _http_text(url: str, headers: dict[str, str] | None = None) -> str:
+    req = urllib.request.Request(url, headers={"User-Agent": UA, **(headers or {})})
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+            return resp.read().decode("utf-8").strip()
+    except urllib.error.HTTPError as e:
+        _die(f"HTTP {e.code} from {url}")
+    except urllib.error.URLError as e:
+        _die(f"network error fetching {url}: {e.reason}")
+
+
+def _emit(value: str, extra: dict[str, Any] | None, as_json: bool) -> None:
+    if as_json:
+        out = {"hash": value}
+        if extra:
+            out.update(extra)
+        print(json.dumps(out, indent=2, sort_keys=True))
+    else:
+        print(value)
+
+
+def _run(cmd: list[str]) -> str:
+    try:
+        return subprocess.run(cmd, check=True, capture_output=True, text=True, timeout=TIMEOUT).stdout.strip()
+    except FileNotFoundError:
+        _die(f"required tool not found: {cmd[0]}", 3)
+    except subprocess.CalledProcessError as e:
+        _die(f"{cmd[0]} failed: {e.stderr.strip() or e.stdout.strip()}")
+
+
+def _gh_headers() -> dict[str, str]:
+    tok = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    h = {"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"}
+    if tok:
+        h["Authorization"] = f"Bearer {tok}"
+    return h
+
+
+# ---------- subcommands ------------------------------------------------------
+
+def cmd_gh_action(args: argparse.Namespace) -> None:
+    """Resolve a GitHub repo tag/branch/SHA to a full 40-char commit SHA."""
+    if "/" not in args.repo:
+        _die("repo must be OWNER/NAME", 2)
+    data = _http_json(f"https://api.github.com/repos/{args.repo}/commits/{args.ref}", _gh_headers())
+    sha = data.get("sha")
+    if not sha or len(sha) != 40:
+        _die(f"unexpected API response: {data!r}")
+    _emit(sha, {
+        "repo": args.repo,
+        "ref": args.ref,
+        "date": data.get("commit", {}).get("committer", {}).get("date"),
+        "message": (data.get("commit", {}).get("message", "") or "").splitlines()[0],
+    }, args.json)
+
+
+def cmd_git_ref(args: argparse.Namespace) -> None:
+    """Resolve a tag/branch to a commit SHA in any git remote (works for non-GitHub)."""
+    if not shutil.which("git"):
+        _die("git not installed", 3)
+    # Try annotated-tag dereference first, then plain ref.
+    out = _run([
+        "git", "ls-remote", args.url,
+        f"refs/tags/{args.ref}^{{}}",
+        f"refs/tags/{args.ref}",
+        f"refs/heads/{args.ref}",
+        args.ref,
+    ])
+    if not out:
+        _die(f"ref {args.ref!r} not found in {args.url}")
+    # Prefer the ^{} line (annotated-tag dereference) if present.
+    chosen = None
+    for line in out.splitlines():
+        sha, _, ref = line.partition("\t")
+        if ref.endswith("^{}"):
+            chosen = sha
+            break
+    if not chosen:
+        chosen = out.splitlines()[0].split("\t", 1)[0]
+    _emit(chosen, {"url": args.url, "ref": args.ref}, args.json)
+
+
+def cmd_oci(args: argparse.Namespace) -> None:
+    """Resolve an OCI image tag to an immutable sha256 digest."""
+    ref = args.image
+    if "@sha256:" in ref:
+        # Already a digest — verify it exists by re-resolving.
+        pass
+    # Prefer crane (fastest, no Docker daemon), then skopeo, then docker buildx.
+    if shutil.which("crane"):
+        digest = _run(["crane", "digest", ref])
+    elif shutil.which("skopeo"):
+        digest = _run(["skopeo", "inspect", f"docker://{ref}", "--format", "{{.Digest}}"])
+    elif shutil.which("docker"):
+        out = _run(["docker", "buildx", "imagetools", "inspect", ref, "--format", "{{json .Manifest}}"])
+        digest = json.loads(out).get("digest", "")
+    else:
+        _die("need one of: crane, skopeo, or docker (with buildx) to resolve OCI digests", 3)
+    if not digest.startswith("sha256:"):
+        _die(f"unexpected digest format: {digest!r}")
+    _emit(digest, {"image": ref}, args.json)
+
+
+def cmd_pypi(args: argparse.Namespace) -> None:
+    """Return SHA256(s) for a PyPI release. Defaults to all artifacts; --wheel/--sdist filter."""
+    data = _http_json(f"https://pypi.org/pypi/{args.package}/{args.version}/json")
+    urls = data.get("urls") or []
+    if not urls:
+        _die(f"no artifacts for {args.package}=={args.version}")
+    rows = []
+    for u in urls:
+        ptype = u.get("packagetype")
+        if args.wheel and ptype != "bdist_wheel":
+            continue
+        if args.sdist and ptype != "sdist":
+            continue
+        rows.append({"filename": u["filename"], "packagetype": ptype, "sha256": u["digests"]["sha256"]})
+    if not rows:
+        _die("no artifacts matched the filter")
+    if args.json:
+        print(json.dumps({"package": args.package, "version": args.version, "artifacts": rows}, indent=2))
+    elif len(rows) == 1:
+        print(rows[0]["sha256"])
+    else:
+        for r in rows:
+            print(f"{r['sha256']}  {r['filename']}")
+
+
+def cmd_npm(args: argparse.Namespace) -> None:
+    """Return the SRI integrity string and tarball SHA1 for a published npm version."""
+    pkg = args.package.replace("/", "%2F") if args.package.startswith("@") else args.package
+    data = _http_json(f"https://registry.npmjs.org/{pkg}/{args.version}")
+    dist = data.get("dist") or {}
+    integrity = dist.get("integrity")
+    if not integrity:
+        _die(f"no dist.integrity for {args.package}@{args.version}")
+    _emit(integrity, {
+        "package": args.package,
+        "version": args.version,
+        "tarball": dist.get("tarball"),
+        "shasum": dist.get("shasum"),
+    }, args.json)
+
+
+def cmd_crate(args: argparse.Namespace) -> None:
+    """Return the SHA256 checksum that crates.io publishes for a crate version."""
+    data = _http_json(f"https://crates.io/api/v1/crates/{args.crate}/{args.version}", {"Accept": "application/json"})
+    ver = data.get("version") or {}
+    checksum = ver.get("checksum")
+    if not checksum:
+        _die(f"no checksum for {args.crate} {args.version}")
+    _emit(checksum, {"crate": args.crate, "version": args.version, "yanked": ver.get("yanked")}, args.json)
+
+
+def cmd_gem(args: argparse.Namespace) -> None:
+    """Return the SHA256 for a published RubyGems version."""
+    data = _http_json(f"https://rubygems.org/api/v2/rubygems/{args.gem}/versions/{args.version}.json")
+    sha = data.get("sha")
+    if not sha:
+        _die(f"no sha for {args.gem} {args.version}")
+    _emit(sha, {"gem": args.gem, "version": args.version, "platform": data.get("platform")}, args.json)
+
+
+def cmd_packagist(args: argparse.Namespace) -> None:
+    """Return dist.shasum + dist.reference for a published Composer package version."""
+    if "/" not in args.package:
+        _die("package must be VENDOR/NAME", 2)
+    data = _http_json(f"https://repo.packagist.org/p2/{args.package}.json")
+    versions = (data.get("packages") or {}).get(args.package) or []
+    match = next((v for v in versions if v.get("version") == args.version), None)
+    if not match:
+        _die(f"version {args.version} not found for {args.package}")
+    dist = match.get("dist") or {}
+    src = match.get("source") or {}
+    primary = dist.get("shasum") or src.get("reference")
+    if not primary:
+        _die("no dist.shasum or source.reference")
+    _emit(primary, {
+        "package": args.package,
+        "version": args.version,
+        "dist_url": dist.get("url"),
+        "source_reference": src.get("reference"),
+    }, args.json)
+
+
+def cmd_gradle_dist(args: argparse.Namespace) -> None:
+    """Return the official SHA256 for a Gradle wrapper distribution."""
+    kind = args.kind  # bin or all
+    sha = _http_text(f"https://services.gradle.org/distributions/gradle-{args.version}-{kind}.zip.sha256")
+    if len(sha) != 64:
+        _die(f"unexpected checksum length: {sha!r}")
+    _emit(sha, {"version": args.version, "kind": kind}, args.json)
+
+
+def cmd_maven(args: argparse.Namespace) -> None:
+    """Return the SHA-256 (or SHA-1 fallback) for a Maven Central artifact."""
+    parts = args.gav.split(":")
+    if len(parts) != 3:
+        _die("gav must be GROUP:ARTIFACT:VERSION", 2)
+    group, artifact, version = parts
+    group_path = group.replace(".", "/")
+    base = (
+        f"https://repo1.maven.org/maven2/{group_path}/{artifact}/"
+        f"{version}/{artifact}-{version}.{args.ext}"
+    )
+    # Try sha256 first, then sha1.
+    for algo in ("sha256", "sha1"):
+        try:
+            sha = _http_text(base + f".{algo}")
+            sha = sha.split()[0]  # files often "<hash>  <filename>"
+            _emit(sha, {"gav": args.gav, "extension": args.ext, "algorithm": algo, "url": base + f".{algo}"}, args.json)
+            return
+        except SystemExit:
+            continue
+    _die(f"no sha256/sha1 sibling found at {base}")
+
+
+def cmd_tf_provider(args: argparse.Namespace) -> None:
+    """List or verify a Terraform / OpenTofu provider version on the registry."""
+    registry = "registry.opentofu.org" if args.opentofu else "registry.terraform.io"
+    if "/" not in args.provider:
+        _die("provider must be NAMESPACE/NAME", 2)
+    data = _http_json(f"https://{registry}/v1/providers/{args.provider}/versions")
+    versions = [v["version"] for v in data.get("versions", [])]
+    if not versions:
+        _die(f"no versions found for {args.provider} on {registry}")
+    if args.version:
+        if args.version not in versions:
+            _die(f"version {args.version} not found for {args.provider}")
+        _emit(args.version, {"provider": args.provider, "registry": registry, "exists": True}, args.json)
+        return
+    if args.json:
+        print(json.dumps({"provider": args.provider, "registry": registry, "versions": versions}, indent=2))
+    else:
+        for v in versions:
+            print(v)
+
+
+def cmd_go_module(args: argparse.Namespace) -> None:
+    """Return go.sum-style hash for a Go module version via the module proxy."""
+    # The proxy serves /<module>/@v/<version>.ziphash containing the h1: hash.
+    mod = args.module.lower()  # proxy is case-folded
+    ver = args.version
+    url = f"https://proxy.golang.org/{mod}/@v/{ver}.ziphash"
+    h1 = _http_text(url)
+    if not h1.startswith("h1:"):
+        _die(f"unexpected ziphash content: {h1!r}")
+    _emit(h1, {"module": args.module, "version": args.version}, args.json)
+
+
+# ---------- arg parser -------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="verify-hash",
+        description="Resolve cryptographic hashes from authoritative upstream sources.",
+    )
+    p.add_argument("--json", action="store_true", help="emit JSON instead of bare hash")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("gh-action", help="resolve a GitHub tag/branch/SHA to a full commit SHA")
+    s.add_argument("repo", help="OWNER/NAME")
+    s.add_argument("ref", help="tag, branch, or short/long SHA")
+    s.set_defaults(func=cmd_gh_action)
+
+    s = sub.add_parser("git-ref", help="resolve a tag/branch on any git remote to a commit SHA")
+    s.add_argument("url", help="git remote URL")
+    s.add_argument("ref", help="tag or branch name")
+    s.set_defaults(func=cmd_git_ref)
+
+    s = sub.add_parser("oci", help="resolve an OCI image tag to an immutable sha256 digest")
+    s.add_argument("image", help="IMAGE:TAG (or IMAGE@sha256:... to re-verify)")
+    s.set_defaults(func=cmd_oci)
+
+    s = sub.add_parser("pypi", help="return SHA256 for a PyPI release")
+    s.add_argument("package")
+    s.add_argument("version")
+    g = s.add_mutually_exclusive_group()
+    g.add_argument("--wheel", action="store_true", help="only wheel artifacts")
+    g.add_argument("--sdist", action="store_true", help="only sdist artifacts")
+    s.set_defaults(func=cmd_pypi)
+
+    s = sub.add_parser("npm", help="return SRI integrity for a published npm version")
+    s.add_argument("package", help="package name (use @scope/name for scoped)")
+    s.add_argument("version")
+    s.set_defaults(func=cmd_npm)
+
+    s = sub.add_parser("crate", help="return SHA256 for a crates.io version")
+    s.add_argument("crate")
+    s.add_argument("version")
+    s.set_defaults(func=cmd_crate)
+
+    s = sub.add_parser("gem", help="return SHA256 for a RubyGems version")
+    s.add_argument("gem")
+    s.add_argument("version")
+    s.set_defaults(func=cmd_gem)
+
+    s = sub.add_parser("packagist", help="return dist.shasum / source.reference for a Composer version")
+    s.add_argument("package", help="VENDOR/NAME")
+    s.add_argument("version")
+    s.set_defaults(func=cmd_packagist)
+
+    s = sub.add_parser("gradle-dist", help="return SHA256 of the official Gradle wrapper distribution")
+    s.add_argument("version")
+    s.add_argument("kind", nargs="?", default="bin", choices=("bin", "all"))
+    s.set_defaults(func=cmd_gradle_dist)
+
+    s = sub.add_parser("maven", help="return SHA256/SHA1 for a Maven Central artifact")
+    s.add_argument("gav", help="GROUP:ARTIFACT:VERSION")
+    s.add_argument("--ext", default="jar", help="artifact extension (default: jar)")
+    s.set_defaults(func=cmd_maven)
+
+    s = sub.add_parser("tf-provider", help="list / verify Terraform or OpenTofu provider versions")
+    s.add_argument("provider", help="NAMESPACE/NAME (e.g. hashicorp/aws)")
+    s.add_argument("version", nargs="?", help="if omitted, list all versions")
+    s.add_argument("--opentofu", action="store_true", help="use the OpenTofu registry")
+    s.set_defaults(func=cmd_tf_provider)
+
+    s = sub.add_parser("go-module", help="return h1: hash for a Go module version via the proxy")
+    s.add_argument("module", help="module path (e.g. github.com/foo/bar)")
+    s.add_argument("version", help="e.g. v1.2.3")
+    s.set_defaults(func=cmd_go_module)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    args.func(args)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_verify_hash.py
+++ b/tests/test_verify_hash.py
@@ -16,6 +16,7 @@ import json
 import sys
 from pathlib import Path
 from unittest.mock import patch
+from urllib.parse import urlparse
 
 import pytest
 
@@ -327,7 +328,12 @@ def test_tf_provider_opentofu_flag_uses_opentofu_registry():
     with patch.object(verify_hash, "_http_json", side_effect=fake), \
          patch("sys.stdout", io.StringIO()):
         verify_hash.main(["tf-provider", "hashicorp/aws", "--opentofu"])
-    assert "registry.opentofu.org" in seen["url"]
+    # Parse the URL and assert on the hostname directly so a malicious value
+    # like https://evil.com/?x=registry.opentofu.org wouldn't pass (CodeQL
+    # py/incomplete-url-substring-sanitization).
+    parsed = urlparse(seen["url"])
+    assert parsed.scheme == "https"
+    assert parsed.hostname == "registry.opentofu.org"
 
 
 # ---------- go-module --------------------------------------------------------

--- a/tests/test_verify_hash.py
+++ b/tests/test_verify_hash.py
@@ -1,0 +1,416 @@
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Unit tests for verify_hash.py.
+
+All upstream HTTP calls are mocked — these tests must not touch the network.
+The point of the helper is to be the *one* place agents go for hashes; if its
+contract drifts (output format, exit codes, subcommand names) every AGENTS-*.md
+file that references it breaks silently. These tests pin that contract.
+"""
+
+import io
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Make verify_hash.py importable as `verify_hash`
+sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "harden-packages"))
+
+import verify_hash  # noqa: E402
+
+# ---------- helpers ----------------------------------------------------------
+
+def _run(argv, json_response=None, text_response=None, run_output=None):
+    """Invoke verify_hash.main(argv) with HTTP / subprocess calls mocked."""
+    patches = []
+    if json_response is not None:
+        patches.append(patch.object(verify_hash, "_http_json", return_value=json_response))
+    if text_response is not None:
+        patches.append(patch.object(verify_hash, "_http_text", return_value=text_response))
+    if run_output is not None:
+        patches.append(patch.object(verify_hash, "_run", return_value=run_output))
+
+    for p in patches:
+        p.start()
+    try:
+        buf = io.StringIO()
+        with patch("sys.stdout", buf):
+            try:
+                verify_hash.main(argv)
+                code = 0
+            except SystemExit as e:
+                code = e.code if isinstance(e.code, int) else 1
+        return code, buf.getvalue()
+    finally:
+        for p in patches:
+            p.stop()
+
+
+# ---------- parser / usage --------------------------------------------------
+
+def test_no_subcommand_errors():
+    with pytest.raises(SystemExit) as exc:
+        verify_hash.main([])
+    assert exc.value.code == 2
+
+
+def test_help_exits_zero(capsys):
+    with pytest.raises(SystemExit) as exc:
+        verify_hash.main(["--help"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    # Every advertised subcommand must appear in --help so AGENTS files stay in sync.
+    for sub in (
+        "gh-action", "git-ref", "oci", "pypi", "npm", "crate", "gem",
+        "packagist", "gradle-dist", "maven", "tf-provider", "go-module",
+    ):
+        assert sub in out
+
+
+# ---------- gh-action --------------------------------------------------------
+
+def test_gh_action_prints_bare_sha():
+    sha = "34e114876b0b11c390a56381ad16ebd13914f8d5"
+    code, out = _run(
+        ["gh-action", "actions/checkout", "v4"],
+        json_response={
+            "sha": sha,
+            "commit": {"committer": {"date": "2025-01-15T00:00:00Z"}, "message": "release v4\n\nbody"},
+        },
+    )
+    assert code == 0
+    assert out.strip() == sha
+
+
+def test_gh_action_json_mode_includes_metadata():
+    sha = "34e114876b0b11c390a56381ad16ebd13914f8d5"
+    code, out = _run(
+        ["--json", "gh-action", "actions/checkout", "v4"],
+        json_response={
+            "sha": sha,
+            "commit": {"committer": {"date": "2025-01-15T00:00:00Z"}, "message": "release v4"},
+        },
+    )
+    assert code == 0
+    data = json.loads(out)
+    assert data["hash"] == sha
+    assert data["repo"] == "actions/checkout"
+    assert data["ref"] == "v4"
+    assert data["date"] == "2025-01-15T00:00:00Z"
+    assert data["message"] == "release v4"
+
+
+def test_gh_action_rejects_bare_repo():
+    with pytest.raises(SystemExit) as exc:
+        verify_hash.main(["gh-action", "checkout", "v4"])
+    assert exc.value.code == 2
+
+
+def test_gh_action_rejects_short_sha_response():
+    # API returns a truncated value — must not be silently accepted.
+    with pytest.raises(SystemExit) as exc, \
+         patch.object(verify_hash, "_http_json", return_value={"sha": "34e1148"}):
+        verify_hash.main(["gh-action", "actions/checkout", "v4"])
+    assert exc.value.code == 1
+
+
+# ---------- pypi -------------------------------------------------------------
+
+_PYPI_REQUESTS = {
+    "urls": [
+        {
+            "packagetype": "bdist_wheel",
+            "filename": "requests-2.32.3-py3-none-any.whl",
+            "digests": {"sha256": "wheelsha"},
+        },
+        {
+            "packagetype": "sdist",
+            "filename": "requests-2.32.3.tar.gz",
+            "digests": {"sha256": "sdistsha"},
+        },
+    ]
+}
+
+
+def test_pypi_all_artifacts_prints_two_lines():
+    code, out = _run(["pypi", "requests", "2.32.3"], json_response=_PYPI_REQUESTS)
+    assert code == 0
+    lines = out.strip().splitlines()
+    assert len(lines) == 2
+    assert "wheelsha  requests-2.32.3-py3-none-any.whl" in lines
+    assert "sdistsha  requests-2.32.3.tar.gz" in lines
+
+
+def test_pypi_sdist_filter_prints_bare_hash():
+    code, out = _run(["pypi", "requests", "2.32.3", "--sdist"], json_response=_PYPI_REQUESTS)
+    assert code == 0
+    assert out.strip() == "sdistsha"
+
+
+def test_pypi_wheel_filter_prints_bare_hash():
+    code, out = _run(["pypi", "requests", "2.32.3", "--wheel"], json_response=_PYPI_REQUESTS)
+    assert code == 0
+    assert out.strip() == "wheelsha"
+
+
+def test_pypi_empty_artifacts_exits_nonzero():
+    with pytest.raises(SystemExit) as exc, \
+         patch.object(verify_hash, "_http_json", return_value={"urls": []}):
+        verify_hash.main(["pypi", "requests", "2.32.3"])
+    assert exc.value.code == 1
+
+
+# ---------- npm --------------------------------------------------------------
+
+def test_npm_prints_sri_integrity():
+    integrity = "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
+    code, out = _run(
+        ["npm", "left-pad", "1.3.0"],
+        json_response={"dist": {"integrity": integrity, "tarball": "https://...", "shasum": "abc"}},
+    )
+    assert code == 0
+    assert out.strip() == integrity
+
+
+def test_npm_scoped_package_url_encoded():
+    integrity = "sha512-AAA"
+    seen = {}
+
+    def fake(url, headers=None):
+        seen["url"] = url
+        return {"dist": {"integrity": integrity, "tarball": "", "shasum": ""}}
+
+    with patch.object(verify_hash, "_http_json", side_effect=fake), \
+         patch("sys.stdout", io.StringIO()):
+        verify_hash.main(["npm", "@scope/pkg", "1.0.0"])
+    assert "%2F" in seen["url"]
+    assert "@scope" in seen["url"]
+
+
+# ---------- crate / gem / packagist -----------------------------------------
+
+def test_crate_prints_checksum():
+    code, out = _run(
+        ["crate", "serde", "1.0.210"],
+        json_response={"version": {"checksum": "cratesha", "yanked": False}},
+    )
+    assert code == 0
+    assert out.strip() == "cratesha"
+
+
+def test_gem_prints_sha():
+    code, out = _run(
+        ["gem", "rails", "7.2.1"],
+        json_response={"sha": "gemsha", "platform": "ruby"},
+    )
+    assert code == 0
+    assert out.strip() == "gemsha"
+
+
+def test_packagist_prefers_dist_shasum_over_source_reference():
+    code, out = _run(
+        ["packagist", "symfony/console", "7.1.5"],
+        json_response={
+            "packages": {
+                "symfony/console": [
+                    {"version": "7.1.4", "dist": {"shasum": "old"}, "source": {"reference": "oldref"}},
+                    {
+                        "version": "7.1.5",
+                        "dist": {"shasum": "newsha", "url": "https://..."},
+                        "source": {"reference": "newref"},
+                    },
+                ]
+            }
+        },
+    )
+    assert code == 0
+    assert out.strip() == "newsha"
+
+
+def test_packagist_unknown_version_exits_nonzero():
+    with pytest.raises(SystemExit) as exc, \
+         patch.object(verify_hash, "_http_json", return_value={"packages": {"v/p": [{"version": "1.0.0"}]}}):
+        verify_hash.main(["packagist", "v/p", "9.9.9"])
+    assert exc.value.code == 1
+
+
+def test_packagist_requires_vendor_slash_name():
+    with pytest.raises(SystemExit) as exc:
+        verify_hash.main(["packagist", "console", "1.0"])
+    assert exc.value.code == 2
+
+
+# ---------- gradle-dist ------------------------------------------------------
+
+def test_gradle_dist_returns_64_char_sha():
+    sha = "a" * 64
+    code, out = _run(["gradle-dist", "8.10"], text_response=sha)
+    assert code == 0
+    assert out.strip() == sha
+
+
+def test_gradle_dist_rejects_bad_length():
+    with pytest.raises(SystemExit) as exc, \
+         patch.object(verify_hash, "_http_text", return_value="deadbeef"):
+        verify_hash.main(["gradle-dist", "8.10"])
+    assert exc.value.code == 1
+
+
+def test_gradle_dist_only_accepts_bin_or_all():
+    with pytest.raises(SystemExit) as exc:
+        verify_hash.main(["gradle-dist", "8.10", "src"])
+    assert exc.value.code == 2
+
+
+# ---------- maven ------------------------------------------------------------
+
+def test_maven_falls_back_to_sha1_when_sha256_missing():
+    calls = []
+
+    def fake_text(url, headers=None):
+        calls.append(url)
+        if url.endswith(".sha256"):
+            raise SystemExit(1)  # mimics _die for HTTP 404
+        return "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef  commons-lang3-3.17.0.jar"
+
+    with patch.object(verify_hash, "_http_text", side_effect=fake_text), \
+         patch("sys.stdout", io.StringIO()) as buf:
+        verify_hash.main(["maven", "org.apache.commons:commons-lang3:3.17.0"])
+    assert calls[0].endswith(".sha256")
+    assert calls[1].endswith(".sha1")
+    assert buf.getvalue().strip() == "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+
+def test_maven_rejects_bad_gav():
+    with pytest.raises(SystemExit) as exc:
+        verify_hash.main(["maven", "commons-lang3"])
+    assert exc.value.code == 2
+
+
+# ---------- tf-provider ------------------------------------------------------
+
+_TF_VERSIONS = {"versions": [{"version": "5.83.0"}, {"version": "5.84.0"}]}
+
+
+def test_tf_provider_lists_versions_when_unspecified():
+    code, out = _run(["tf-provider", "hashicorp/aws"], json_response=_TF_VERSIONS)
+    assert code == 0
+    assert out.strip().splitlines() == ["5.83.0", "5.84.0"]
+
+
+def test_tf_provider_verifies_known_version():
+    code, out = _run(["tf-provider", "hashicorp/aws", "5.84.0"], json_response=_TF_VERSIONS)
+    assert code == 0
+    assert out.strip() == "5.84.0"
+
+
+def test_tf_provider_rejects_unknown_version():
+    with pytest.raises(SystemExit) as exc, \
+         patch.object(verify_hash, "_http_json", return_value=_TF_VERSIONS):
+        verify_hash.main(["tf-provider", "hashicorp/aws", "9.9.9"])
+    assert exc.value.code == 1
+
+
+def test_tf_provider_opentofu_flag_uses_opentofu_registry():
+    seen = {}
+
+    def fake(url, headers=None):
+        seen["url"] = url
+        return _TF_VERSIONS
+
+    with patch.object(verify_hash, "_http_json", side_effect=fake), \
+         patch("sys.stdout", io.StringIO()):
+        verify_hash.main(["tf-provider", "hashicorp/aws", "--opentofu"])
+    assert "registry.opentofu.org" in seen["url"]
+
+
+# ---------- go-module --------------------------------------------------------
+
+def test_go_module_returns_h1_hash():
+    h1 = "h1:abcdef=="
+    code, out = _run(["go-module", "github.com/stretchr/testify", "v1.9.0"], text_response=h1)
+    assert code == 0
+    assert out.strip() == h1
+
+
+def test_go_module_rejects_non_h1_response():
+    with pytest.raises(SystemExit) as exc, \
+         patch.object(verify_hash, "_http_text", return_value="deadbeef"):
+        verify_hash.main(["go-module", "github.com/foo/bar", "v1.0.0"])
+    assert exc.value.code == 1
+
+
+def test_go_module_proxy_lowercases_module_path():
+    """proxy.golang.org case-folds module paths; verify the URL we build matches."""
+    seen = {}
+
+    def fake(url, headers=None):
+        seen["url"] = url
+        return "h1:ok="
+
+    with patch.object(verify_hash, "_http_text", side_effect=fake), \
+         patch("sys.stdout", io.StringIO()):
+        verify_hash.main(["go-module", "github.com/Stretchr/Testify", "v1.9.0"])
+    assert "github.com/stretchr/testify" in seen["url"]
+    assert "github.com/Stretchr/Testify" not in seen["url"]
+
+
+# ---------- oci --------------------------------------------------------------
+
+def test_oci_uses_crane_when_available():
+    with patch("shutil.which", side_effect=lambda t: "/usr/local/bin/crane" if t == "crane" else None), \
+         patch.object(verify_hash, "_run", return_value="sha256:" + "a" * 64), \
+         patch("sys.stdout", io.StringIO()) as buf:
+        verify_hash.main(["oci", "node:20-alpine"])
+    assert buf.getvalue().strip() == "sha256:" + "a" * 64
+
+
+def test_oci_errors_when_no_tool_available():
+    with patch("shutil.which", return_value=None), \
+         pytest.raises(SystemExit) as exc:
+        verify_hash.main(["oci", "node:20-alpine"])
+    assert exc.value.code == 3
+
+
+def test_oci_rejects_non_sha256_digest():
+    with patch("shutil.which", side_effect=lambda t: "/usr/local/bin/crane" if t == "crane" else None), \
+         patch.object(verify_hash, "_run", return_value="md5:something"), \
+         pytest.raises(SystemExit) as exc:
+        verify_hash.main(["oci", "node:20-alpine"])
+    assert exc.value.code == 1
+
+
+# ---------- git-ref ----------------------------------------------------------
+
+def test_git_ref_prefers_annotated_tag_dereference():
+    output = (
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\trefs/tags/v1.0.0\n"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\trefs/tags/v1.0.0^{}\n"
+    )
+    with patch("shutil.which", return_value="/usr/bin/git"), \
+         patch.object(verify_hash, "_run", return_value=output), \
+         patch("sys.stdout", io.StringIO()) as buf:
+        verify_hash.main(["git-ref", "https://example.com/x.git", "v1.0.0"])
+    assert buf.getvalue().strip() == "b" * 40
+
+
+def test_git_ref_falls_back_to_first_when_no_dereference():
+    output = "cccccccccccccccccccccccccccccccccccccccc\trefs/heads/main\n"
+    with patch("shutil.which", return_value="/usr/bin/git"), \
+         patch.object(verify_hash, "_run", return_value=output), \
+         patch("sys.stdout", io.StringIO()) as buf:
+        verify_hash.main(["git-ref", "https://example.com/x.git", "main"])
+    assert buf.getvalue().strip() == "c" * 40
+
+
+def test_git_ref_no_git_binary_exits_3():
+    with patch("shutil.which", return_value=None), \
+         pytest.raises(SystemExit) as exc:
+        verify_hash.main(["git-ref", "https://example.com/x.git", "v1.0.0"])
+    assert exc.value.code == 3

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.10"
+requires-python = ">=3.10, <3.15"
 
 [options]
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.


### PR DESCRIPTION
## Summary

Adds a single-file, dependency-free CLI alongside `audit.py` that resolves cryptographic hashes from authoritative upstream sources, and updates every `agents/AGENTS-*.md` file with explicit guidance to use it instead of inventing hashes.

The goal is to give AI agents using the harden-packages skill *exactly one tool* to reach for when pinning by hash, so they never have to invent, guess, autocomplete, or extrapolate a SHA / digest / integrity value. A fabricated hash either fails verification (best case) or — if it accidentally collides — silently pins to the wrong artifact, which is a supply-chain incident.

## What's new

### `skills/harden-packages/verify_hash.py`

Single-file, zero-dependency Python CLI. Subcommands cover every ecosystem the skill audits:

| Subcommand | Source | Returns |
|---|---|---|
| `gh-action OWNER/REPO REF` | api.github.com | full 40-char commit SHA |
| `git-ref URL REF` | `git ls-remote` (any remote) | commit SHA |
| `oci IMAGE:TAG` | `crane` / `skopeo` / `docker buildx` | `sha256:...` digest |
| `pypi PKG VER [--wheel\|--sdist]` | pypi.org | sha256 |
| `npm PKG VER` | registry.npmjs.org | `sha512-...` SRI integrity |
| `crate NAME VER` | crates.io | sha256 |
| `gem NAME VER` | rubygems.org | sha256 |
| `packagist VENDOR/PKG VER` | repo.packagist.org | dist.shasum / source.reference |
| `gradle-dist VER [bin\|all]` | services.gradle.org | sha256 |
| `maven GROUP:ARTIFACT:VER` | repo1.maven.org | sha256 (falls back to sha1) |
| `tf-provider NS/NAME [VER] [--opentofu]` | registry.terraform.io / opentofu | list / verify versions |
| `go-module MODULE VER` | proxy.golang.org `.ziphash` | `h1:` hash |

Default output is the bare hash on stdout, so it's shell-friendly:

\`\`\`bash
SHA=\$(python skills/harden-packages/verify_hash.py gh-action actions/checkout v4)
\`\`\`

\`--json\` adds metadata (date, message, URL, etc.). Documented exit codes:

- \`0\` success
- \`1\` upstream lookup failed (network, 404, version doesn't exist
- `2` usage error
- `3` required external tool missing (only `oci` and `git-ref`)

### `agents/AGENTS-*.md` (11 files)

Each gains a new top-level `## Hash Verification: Never Fabricate` section that:

1. States the rule (never invent / guess / autocomplete / extrapolate a hash)
2. Explains the two failure modes (broken build, or wrong-artifact pin = supply-chain incident)
3. Points at `verify_hash.py` as the preferred path when the harden-packages skill is loaded
4. Lists a short ecosystem-specific manual fallback (`gh` / `curl` / `jq` / `crane`) for repos that adopt only the AGENTS file
5. Ends with "if you cannot verify, stop and ask the user"

This closes a real gap: prior AGENTS guidance assumed lockfile-generated hashes (`npm install`, `pip-compile --generate-hashes`, etc.) but said nothing about the ad-hoc SHA / digest pinning agents do most often — `actions/checkout@<sha>`, `FROM node:20@sha256:...`, `go install pkg@<sha>`, `rev = "..."` in Cargo.toml, etc.

### `skills/harden-packages/SKILL.md`

New `## Companion tool: verify_hash.py` section sits right after the `audit.py` section, with one-line examples for every subcommand. An agent loading the skill now discovers both tools without having to read the AGENTS files first.

### `tests/test_verify_hash.py`

35 unit tests covering:

- Argument parsing (missing subcommand → exit 2; `--help` lists every subcommand the AGENTS files reference)
- JSON vs bare output mode
- Every subcommand's success path (with realistic mocked responses)
- Failure paths: short-SHA rejection, unknown version, missing tool (exit 3), bad digest format, bad GAV/repo format
- Subtleties the script gets right: Go proxy case-folding (`Stretchr/Testify` → `stretchr/testify`), scoped npm URL-encoding (`@scope/pkg` → `@scope%2Fpkg`), annotated-tag dereference (`^{}`), Maven `.sha256` → `.sha1` fallback, packagist preferring `dist.shasum` over `source.reference`

All upstream HTTP and subprocess calls are mocked — the suite stays offline.

### Housekeeping

- `.gitignore`: add `.claude/` so local Claude Code settings don't trip REUSE.
- `uv.lock`: regenerated to match the `requires-python = ">=3.10, <3.15"` bound added in #36 (the lockfile wasn't updated in that commit; `uv run` regenerated it on first use here).

## Verification

```
$ uv run pytest -q
252 passed in 0.84s

$ uv run ruff check skills/harden-packages/verify_hash.py tests/test_verify_hash.py
All checks passed!

$ uv run reuse lint
Congratulations! Your project is compliant with version 3.3 of the REUSE Specification :-)
```

Live smoke tests against real registries (not part of CI; offline mocks in test suite):

```
$ python skills/harden-packages/verify_hash.py gh-action actions/checkout v4
34e114876b0b11c390a56381ad16ebd13914f8d5

$ python skills/harden-packages/verify_hash.py pypi requests 2.32.3 --sdist
55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760

$ python skills/harden-packages/verify_hash.py crate serde 1.0.210
c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a

$ python skills/harden-packages/verify_hash.py gradle-dist 8.10
5b9c5eb3f9fc2c94abaea57d90bd78747ca117ddbbf96c859d3741181a12bf2a
```

## Out of scope / follow-ups

- The script intentionally doesn't try to validate Sigstore / cosign bundles, in-toto attestations, or SLSA provenance — those are a separate concern from "resolve the hash for this artifact" and warrant a dedicated subcommand if/when there's demand.
- The `oci` subcommand requires one of `crane`, `skopeo`, or `docker` to be installed on PATH; it doesn't fall back to a pure-HTTP registry implementation (which would need full OCI auth handling). The `exit 3` contract makes this obvious.
EOF
)