### PR TITLE
fix: dogfood npm .npmrc and fix audit.py requires-python false positive

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+#
+# SPDX-License-Identifier: MIT
+
+# Dogfooding docs/nodejs.md "CI Recommended Configuration".
+# CI installs are already lockfile-driven (npm ci --ignore-scripts);
+# these settings harden the local lockfile-regeneration path
+# (npm install / npm update) where new versions are actually resolved.
+
+# New deps are saved as exact versions, never ^ ranges
+save-exact=true
+
+# Refuse to resolve any version published in the last 7 days
+# (10080 minutes). Requires npm >= 11.10; older npm ignores the key.
+minimum-release-age=10080
+
+audit=true
+fund=false

--- a/skills/harden-packages/audit.py
+++ b/skills/harden-packages/audit.py
@@ -295,6 +295,10 @@ def audit_python(root):
                 in_deps = True
             elif line.startswith("[") and in_deps:
                 in_deps = False
+            # requires-python is an interpreter constraint, not a package
+            # dependency — a bounded range there is recommended, not loose.
+            if re.match(r"\s*requires-python\s*=", line):
+                continue
             if in_deps or "dependencies" in line:
                 # Look for lines that have package specs without ==
                 m = re.search(r'"([^"]+[><=!~][^"]*)"', line)

--- a/tests/test_audit_python.py
+++ b/tests/test_audit_python.py
@@ -89,6 +89,26 @@ def test_exact_pins_loose_detected(tmp_path):
     assert len(result["exact_pins"]["loose"]) > 0
 
 
+def test_requires_python_not_flagged_as_loose_pin(tmp_path):
+    # requires-python is an interpreter constraint, not a dependency;
+    # a bounded range there is the recommended configuration.
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nrequires-python = ">=3.10,<3.15"\ndependencies = ["requests==2.31.0"]\n'
+    )
+    result = audit.audit_python(str(tmp_path))
+    assert result["exact_pins"]["status"] == "pass"
+    assert result["exact_pins"]["loose"] == []
+
+
+def test_requires_python_skipped_but_loose_deps_still_flagged(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nrequires-python = ">=3.10,<3.15"\ndependencies = ["requests>=2.0.0"]\n'
+    )
+    result = audit.audit_python(str(tmp_path))
+    assert result["exact_pins"]["status"] == "fail"
+    assert result["exact_pins"]["loose"] == ["requests>=2.0.0"]
+
+
 # ---------------------------------------------------------------------------
 # UV config
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Ran the repo's own `audit.py` against itself (`uv run python skills/harden-packages/audit.py --path .`). Two findings, both fixed:

### 1. Missing `.npmrc` (real gap)

[docs/nodejs.md](docs/nodejs.md) recommends committing an `.npmrc` with `save-exact` + `minimum-release-age`, but this repo (which uses npm for `markdownlint-cli2`) had none. CI was already protected — `npm ci --ignore-scripts` is fully lockfile-driven — so the exposure was the **local lockfile-regeneration path**: `npm install`/`npm update` resolved new versions with no cooldown and no exact-save enforcement. This is precisely the update-window gap described in [docs/transitive.md](docs/transitive.md).

Adds the documented template: `save-exact=true`, `minimum-release-age=10080` (7 days), `audit=true`, `fund=false`. npm < 11.10 ignores the cooldown key harmlessly.

### 2. `audit_python()` false positive (bug)

The audit flagged `requires-python = ">=3.10,<3.15"` as a loose dependency pin — failing on this repo's own recommended configuration. `requires-python` is an interpreter constraint, not a package dependency; the `[project]` section-tracking logic treated any quoted string containing comparison operators as a package spec. Now skipped, with two regression tests (skip `requires-python`; still flag genuinely loose deps on the same file).

## Verification

- [x] `uv run pytest tests/` — 280/280 pass (+2 new)
- [x] `uv run ruff check` / `ruff format --check` on audit.py — clean
- [x] Self-audit re-run: `python.exact_pins` and `nodejs.minimum_release_age` both now `pass`
- [x] `npm ci --ignore-scripts` works with the new `.npmrc` (npm 11.12.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)