### PR TITLE
fix(docs): correct npm provenance verification command

### DIFF
--- a/agents/AGENTS-nodejs.md
+++ b/agents/AGENTS-nodejs.md
@@ -101,6 +101,10 @@ Run a vulnerability audit whenever dependencies change:
 npm audit --audit-level=moderate
 pnpm audit --audit-level=moderate
 yarn npm audit
+
+# npm: also verify registry signatures + provenance attestations for the
+# full tree (catches tampered artifacts that hash verification cannot)
+npm audit signatures
 ```
 
 If the audit reports vulnerabilities, do not merge the change until they are resolved or explicitly acknowledged with a documented justification.

--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -87,9 +87,14 @@ npm audit                      # check for known vulnerabilities
 npm audit fix                  # auto-fix where possible
 npm audit --audit-level=high   # fail CI only on high/critical
 
-# Verify package provenance (requires registry support)
-npm install --foreground-scripts
+# Verify registry signatures and provenance attestations for every
+# package in the tree (direct and transitive). Fails if any installed
+# artifact has a missing or invalid signature, or if a package that
+# publishes provenance has an attestation that doesn't verify.
+npm audit signatures
 ```
+
+`npm audit signatures` complements the lockfile's integrity hashes: the lockfile proves the artifact didn't change since it was locked, while signature verification proves the artifact is the one the registry actually published. A tampered lockfile entry pointing at a look-alike artifact passes hash verification (the hash was recorded from the tampered artifact) but fails signature verification. Run it in CI after `npm ci`.
 
 ### Workspace / Monorepo
 

--- a/skills/harden-packages/SKILL.md
+++ b/skills/harden-packages/SKILL.md
@@ -726,6 +726,7 @@ Use this section only if `audit.py` cannot be run. It replicates what the script
 - Bun ≥ 1.3: is `minimumReleaseAge` set in `bunfig.toml`?
 - pnpm: is `onlyBuiltDependencies` (allowlist) or `ignoredBuiltDependencies` configured?
 - Does CI use `npm ci` / `pnpm install --frozen-lockfile` / `yarn install --immutable` / `bun install --frozen-lockfile`?
+- npm: does CI run `npm audit signatures` after install? It verifies registry signatures and provenance attestations for the full tree — catching tampered artifacts that lockfile hash verification cannot (the lockfile hash is recorded *from* the artifact, so a substituted artifact carries a matching hash).
 
 ### Python (pip / uv)
 


### PR DESCRIPTION
## Summary

[docs/nodejs.md](docs/nodejs.md)'s "Audit and Signatures" section showed `npm install --foreground-scripts` under "Verify package provenance" — that flag only makes lifecycle-script output visible and does not verify anything. The correct command is **`npm audit signatures`**, which verifies registry signatures and provenance attestations for every package in the tree, including transitives.

Also expands the section to explain the complementary relationship with lockfile hashes: the lockfile proves an artifact didn't change since locking, but a tampered lockfile entry carries a matching hash *for the substituted artifact* — only signature verification catches that.

Propagated per the CONTRIBUTING checklist:
- `docs/nodejs.md` — fixed command + rationale
- `agents/AGENTS-nodejs.md` — added to Security Audit commands
- `skills/harden-packages/SKILL.md` — added to Node.js manual checklist

## Test plan

- [x] `npx markdownlint-cli2` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)