### PR TITLE
docs: add Renovate guide for cross-ecosystem cooldown coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ cp -r skills/harden-packages ~/.claude/skills/
 |-----|--------|
 | [Transitive Dependencies](docs/transitive.md) | Which controls cover indirect dependencies, the update-window gap, per-ecosystem coverage matrix |
 | [Dependabot](docs/dependabot.md) | Cooldown configuration per ecosystem, semver-level delay, known Terraform provider bug |
+| [Renovate](docs/renovate.md) | `minimumReleaseAge` for every package manager — PR-level cooldown for the ecosystems with no native age gate (Maven, Gradle, Go, Composer, Bundler, NuGet, Helm, Terraform) |
 | [Harden-Runner](docs/harden-runner.md) | Runtime CI egress control, audit → block mode, per-ecosystem `allowed-endpoints` |
 | [GitHub Actions](docs/github-actions.md) | SHA pinning, runner image pinning, least-privilege permissions, expression injection, OIDC, CODEOWNERS, `persist-credentials: false`, workflow concurrency, zizmor static analysis, CodeQL SAST, fuzzing, dependency-review on PRs, OpenSSF Scorecard, `SECURITY.md` + private vulnerability reporting |
 | [Container Images](docs/docker.md) | Base image digest pinning, official images, distroless, Docker Scout, Cosign, Dependabot |
@@ -116,6 +117,8 @@ cp -r skills/harden-packages ~/.claude/skills/
 | [Bundler](docs/ruby.md#bundler) | ❌ No | — | (use Dependabot + exact pins) | — |
 | [NuGet (.NET)](docs/dotnet.md#nuget) | ❌ No | — | (use Dependabot cooldown + exact pins) | — |
 | [Terraform](docs/terraform.md#terraform) / [OpenTofu](docs/terraform.md#opentofu) | ❌ No | — | (use exact `=` pins + Dependabot²) | — |
+
+For every ❌ row, [Renovate's `minimumReleaseAge`](docs/renovate.md) provides the equivalent gate at the PR level — it works across all of Renovate's supported package managers, unlike the native mechanisms above which are resolver-level and ecosystem-specific.
 
 ---
 

--- a/docs/dependabot.md
+++ b/docs/dependabot.md
@@ -77,4 +77,6 @@ Per-package overrides using `include` and `exclude`:
 - **`github-actions` ecosystem special case:** action tags (`v4`, `v4.1.2`) aren't always parsed as SemVer by Dependabot, so `semver-major-days` / `semver-minor-days` / `semver-patch-days` do not reliably apply. For the `github-actions` ecosystem, rely on `default-days` only.
 - **Security update PRs automatically bypass the cooldown** — a CVE-triggered Dependabot PR is never delayed, regardless of `cooldown` settings.
 - Cooldown only gates automated version update PRs. A developer running `npm install foo` or `go get` locally bypasses it entirely.
-- Supported for all ecosystems including npm, pip, gomod, cargo, NuGet, Helm, and more.
+- Supported for all ecosystems including npm, pip, gomod, cargo, NuGet, and more — but **not Helm chart dependencies**, which Dependabot does not update at all.
+
+**Alternative:** [Renovate](renovate.md) provides the equivalent cooldown (`minimumReleaseAge`) across every manager it supports, with per-package rules and a dependency dashboard showing held-back updates. See the comparison table in that doc for when to prefer which.

--- a/docs/renovate.md
+++ b/docs/renovate.md
@@ -1,0 +1,131 @@
+<!--
+SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+SPDX-License-Identifier: MIT
+-->
+
+# Renovate Integration
+
+Renovate is an alternative to Dependabot for automated dependency updates. For supply chain
+hardening it has one decisive advantage: **`minimumReleaseAge` works for every package manager
+Renovate supports**, including the ecosystems where neither the package manager nor Dependabot
+provides a reliable cooldown — Maven, Gradle, Go modules, Composer, Bundler, NuGet, Helm, and
+Terraform.
+
+The [Transitive Dependency Coverage](transitive.md) matrix marks those ecosystems ❌ for native
+age gates. Renovate closes that gap at the PR level: an update PR is not offered until the new
+version has been published for at least the configured window.
+
+## Configuration
+
+Renovate reads `renovate.json` (or `.github/renovate.json`, `renovate.json5`,
+`.renovaterc.json`) in the repository root:
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
+  "dependencyDashboard": true,
+  "osvVulnerabilityAlerts": true,
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["major"],
+      "minimumReleaseAge": "30 days"
+    },
+    {
+      "matchUpdateTypes": ["patch"],
+      "minimumReleaseAge": "3 days"
+    }
+  ]
+}
+```
+
+**Key settings:**
+
+- **`minimumReleaseAge`** — the cooldown window. Accepts human-readable durations
+  (`"3 days"`, `"2 weeks"`). Applies to every manager in the repository unless overridden
+  in a `packageRules` entry.
+- **`internalChecksFilter: "strict"`** — when several new versions exist, propose the newest
+  one that *satisfies* the age window instead of waiting for the very latest to age. Without
+  this, a package releasing frequently can keep resetting the clock and never produce an
+  update PR.
+- **`packageRules`** — per-update-type, per-manager, or per-package overrides. The example
+  above mirrors the Dependabot semver-level convention used elsewhere in this repository
+  (30 days major / 7 days minor / 3 days patch).
+- **`osvVulnerabilityAlerts`** — raise PRs for OSV-database vulnerabilities in addition to
+  GitHub Security Advisories.
+- **`dependencyDashboard`** — creates a tracking issue listing updates currently held by the
+  age window, so delayed updates are visible rather than silent.
+
+Security-alert PRs (from `vulnerabilityAlerts` / `osvVulnerabilityAlerts`) bypass
+`minimumReleaseAge` — a fix for a disclosed CVE is never delayed, matching Dependabot's
+cooldown-bypass behaviour.
+
+## Per-manager cooldowns for the gap ecosystems
+
+A `packageRules` entry scoped with `matchManagers` applies the window only where you need it —
+useful if Dependabot handles some ecosystems and Renovate covers the rest:
+
+```json
+{
+  "packageRules": [
+    {
+      "matchManagers": ["maven", "gradle", "gomod", "composer", "bundler", "nuget", "helmv3", "terraform"],
+      "minimumReleaseAge": "7 days"
+    }
+  ]
+}
+```
+
+## Renovate vs Dependabot
+
+| | Dependabot | Renovate |
+|---|---|---|
+| Cooldown mechanism | `cooldown` block per ecosystem | `minimumReleaseAge` global or per-rule |
+| Cooldown ecosystem coverage | All supported ecosystems, but [known Terraform provider bug](https://github.com/dependabot/dependabot-core/issues/13715) | All supported managers, including Helm chart dependencies (which Dependabot doesn't update at all) |
+| Semver-level windows | `semver-major/minor/patch-days` keys | `packageRules` + `matchUpdateTypes` |
+| Per-package overrides | `include` / `exclude` lists | `packageRules` + `matchPackageNames` (more expressive) |
+| Security PRs bypass cooldown | ✅ Yes | ✅ Yes |
+| Vulnerability sources | GitHub Security Advisories | GitHub Security Advisories + OSV (`osvVulnerabilityAlerts`) |
+| Visibility of held updates | None — delayed PRs simply don't appear | Dependency Dashboard issue lists pending updates |
+| Grouped updates | `groups` config | `packageRules` grouping / built-in presets |
+| Hosting | GitHub-native, zero setup | Hosted GitHub App (Mend) or self-hosted |
+| Configuration review | `dependabot.yml` in-repo | `renovate.json` in-repo |
+
+**When to choose which:**
+
+- **Dependabot** is the lower-friction default for repositories whose ecosystems all have
+  either a native package-manager age gate (npm, pnpm, Yarn, Bun, uv, Cargo via
+  `cargo-cooldown`) or acceptable Dependabot cooldown coverage. It is GitHub-native and
+  requires no third-party app authorization.
+- **Renovate** is the better choice when the repository depends on Maven, Gradle, Go,
+  Composer, Bundler, NuGet, Helm, or Terraform and you want a PR-level age gate that
+  actually applies — or when you want the Dependency Dashboard's visibility into what is
+  currently being held back.
+- Running **both** is possible (e.g. Dependabot for `github-actions`, Renovate for
+  application dependencies) but configure disjoint ecosystem coverage so they don't open
+  duplicate PRs.
+
+## Limitations
+
+- Like Dependabot's cooldown, `minimumReleaseAge` gates the *update PR*, not the resolver.
+  A developer running `go get`, `bundle update`, or `mvn versions:use-latest-releases`
+  locally bypasses it entirely. Where a native resolver-level gate exists (npm, pnpm, Yarn,
+  Bun, uv, cargo-cooldown), configure it as the primary control and treat Renovate as the
+  PR-level layer on top.
+- New *transitive* packages introduced by an aged direct update are not individually
+  age-checked — the same update-window caveat described in
+  [Transitive Dependency Coverage](transitive.md).
+- Renovate needs release timestamps from the registry to evaluate age. For registries that
+  don't expose them (some private mirrors), the check is skipped silently — verify behaviour
+  against your registry before relying on it.
+
+## Reference
+
+- [Renovate documentation](https://docs.renovatebot.com/)
+- [`minimumReleaseAge`](https://docs.renovatebot.com/configuration-options/#minimumreleaseage)
+- [`internalChecksFilter`](https://docs.renovatebot.com/configuration-options/#internalchecksfilter)
+- [`packageRules`](https://docs.renovatebot.com/configuration-options/#packagerules)
+- [Renovate vulnerability alerts](https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts)

--- a/docs/transitive.md
+++ b/docs/transitive.md
@@ -94,6 +94,11 @@ configured number of days. But the transitive packages that `express@4.19.2` int
 not individually subject to cooldown. Dependabot cooldown is a useful secondary gate, not a
 replacement for a native resolver-level implementation.
 
+For the ❌ rows above, [Renovate's `minimumReleaseAge`](renovate.md) provides the same PR-level
+gate as Dependabot cooldown but works uniformly across all of Renovate's supported managers —
+including Maven, Gradle, NuGet, Composer, Bundler, Helm, and Terraform. It shares the same
+direct-dependencies-only limitation.
+
 ## The update window
 
 The most important residual gap across all ecosystems is the moment when you merge a dependency
@@ -114,6 +119,9 @@ published yesterday.
 
 **Mitigations for ecosystems without native cooldown:**
 
+0. **Use [Renovate](renovate.md) with `minimumReleaseAge`** so the direct update itself is
+   age-gated at the PR level — this shrinks (but does not eliminate) the window, since the
+   transitives a 7-day-old release introduces have usually also had time to be vetted.
 1. **Review lockfile diffs carefully on every dependency update PR.** A new transitive package
    appearing in `go.sum`, `Gemfile.lock`, `composer.lock`, or `packages.lock.json` is a signal
    worth investigating — check when it was published and whether it was previously a transitive


### PR DESCRIPTION
## Summary

The [transitive coverage matrix](docs/transitive.md) marks Maven, Gradle, Go, Composer, Bundler, NuGet, Helm, and Terraform ❌ for native age gates. Renovate's `minimumReleaseAge` closes that gap at the PR level for **all** of its supported managers — this PR documents it as a first-class cross-cutting control, parallel to [docs/dependabot.md](docs/dependabot.md).

**New: [docs/renovate.md](docs/renovate.md)**
- Config guide: `minimumReleaseAge`, `internalChecksFilter: "strict"` (avoids the always-resetting-clock problem on fast-releasing packages), `packageRules` mirroring the repo's 30/7/3 semver convention, `osvVulnerabilityAlerts`, dependency dashboard
- Per-manager scoping example for running Renovate only on the gap ecosystems
- Dependabot vs Renovate comparison table and when-to-choose-which guidance
- Honest limitations: PR-level not resolver-level, direct deps only, requires registry release timestamps

**Cross-links:**
- README cross-cutting table row + note under the native minimum-release-age matrix
- transitive.md: Renovate as the first update-window mitigation
- dependabot.md: comparison cross-link — and a correction: it claimed Dependabot cooldown supports Helm, but Dependabot doesn't update Helm chart dependencies at all (the README matrix already said so; the two docs now agree)

## Test plan

- [x] `npx markdownlint-cli2` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)