### PR TITLE
feat: reusable hardening-audit action + self-audit workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,8 @@ jobs:
           version: "0.11.11"
 
       - run: uv sync --frozen --group dev --python 3.12
-      - run: uv run ruff check skills/harden-packages/audit.py
-      - run: uv run ruff format --check skills/harden-packages/audit.py
+      - run: uv run ruff check skills/harden-packages/audit.py skills/harden-packages/report.py
+      - run: uv run ruff format --check skills/harden-packages/audit.py skills/harden-packages/report.py
 
   python-test:
     name: Python tests (py${{ matrix.python-version }})

--- a/.github/workflows/self-audit.yml
+++ b/.github/workflows/self-audit.yml
@@ -2,14 +2,17 @@
 #
 # SPDX-License-Identifier: MIT
 
-# Dogfooding: run this repo's own audit.py against this repo and fail if any
-# hardening regression appears (a workflow added without harden-runner, a
-# dependency ecosystem missing a Dependabot cooldown, a loose version pin...).
-# The findings table plus recommended changes land in the job summary, so a
-# failing PR check shows exactly what to fix and links the relevant doc.
+# Dogfooding: run this repo's own audit action (action.yml at the repo root)
+# against this repo and fail if any hardening regression appears (a workflow
+# added without harden-runner, a dependency ecosystem missing a Dependabot
+# cooldown, a loose version pin...). The findings table plus recommended
+# changes land in the job summary, so a failing PR check shows exactly what
+# to fix and links the relevant doc.
 #
-# Both scripts are stdlib-only — no package installation step, which keeps the
-# egress allowlist down to what checkout itself needs.
+# `uses: ./` exercises the same composite action consumers reference as
+# `jordanconway/package-manager-hardening@<sha>`. The underlying scripts are
+# stdlib-only — no package installation step, which keeps the egress
+# allowlist down to what checkout itself needs.
 
 name: Self-audit
 
@@ -46,13 +49,7 @@ jobs:
         with:
           persist-credentials: false
 
-      # Gate: report.py exits 1 on any "fail"/"missing" finding. The summary
+      # Gate: the action exits 1 on any "fail"/"missing" finding. The summary
       # is written before the gate fires so failures are always explained.
       - name: Run audit and publish findings
-        run: |
-          python3 skills/harden-packages/audit.py --path . --pretty > audit.json
-          gate=0
-          python3 skills/harden-packages/report.py audit.json > report.md || gate=$?
-          cat report.md >> "$GITHUB_STEP_SUMMARY"
-          cat report.md
-          exit "$gate"
+        uses: ./

--- a/.github/workflows/self-audit.yml
+++ b/.github/workflows/self-audit.yml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+#
+# SPDX-License-Identifier: MIT
+
+# Dogfooding: run this repo's own audit.py against this repo and fail if any
+# hardening regression appears (a workflow added without harden-runner, a
+# dependency ecosystem missing a Dependabot cooldown, a loose version pin...).
+# The findings table plus recommended changes land in the job summary, so a
+# failing PR check shows exactly what to fix and links the relevant doc.
+#
+# Both scripts are stdlib-only — no package installation step, which keeps the
+# egress allowlist down to what checkout itself needs.
+
+name: Self-audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "23 8 * * 1" # weekly, Monday 08:23 UTC — catches drift between PRs
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  self-audit:
+    name: Audit this repo with audit.py
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: block
+          disable-sudo: true
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      # Gate: report.py exits 1 on any "fail"/"missing" finding. The summary
+      # is written before the gate fires so failures are always explained.
+      - name: Run audit and publish findings
+        run: |
+          python3 skills/harden-packages/audit.py --path . --pretty > audit.json
+          gate=0
+          python3 skills/harden-packages/report.py audit.json > report.md || gate=$?
+          cat report.md >> "$GITHUB_STEP_SUMMARY"
+          cat report.md
+          exit "$gate"

--- a/README.md
+++ b/README.md
@@ -59,6 +59,19 @@ curl -o AGENTS.md https://raw.githubusercontent.com/jordanconway/package-manager
 cp -r skills/harden-packages ~/.claude/skills/
 ```
 
+**For CI:** run the audit as a GitHub Actions check in any repo. The action is dependency-free (Python stdlib only), publishes a findings table with remediation hints to the job summary, and fails the job on hardening gaps:
+
+```yaml
+# After your actions/checkout step. Resolve <commit-sha> from the release tag:
+#   gh api repos/jordanconway/package-manager-hardening/commits/<tag> --jq .sha
+- uses: jordanconway/package-manager-hardening@<commit-sha> # vX.Y.Z
+  with:
+    path: "."          # repository root to audit (default)
+    warn-only: "false" # "true" reports findings without failing the job
+```
+
+Start with `warn-only: "true"`, fix the reported findings, then drop it to make the audit a required check. See [docs/skill.md](docs/skill.md#running-the-audit-in-ci-no-llm-required) for details and outputs.
+
 ---
 
 ## Contents

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+#
+# SPDX-License-Identifier: MIT
+
+# Composite action: run the package-manager hardening audit against the
+# consumer's checked-out repository and publish findings to the job summary.
+#
+# Both underlying scripts (skills/harden-packages/audit.py and report.py) are
+# Python-stdlib-only, so the action installs nothing and needs no egress
+# beyond what the consumer's own checkout already required. python3 must be
+# on PATH (true for GitHub-hosted ubuntu-* and macos-* runners).
+#
+# Usage (in the consumer repo, after actions/checkout):
+#
+#   - uses: jordanconway/package-manager-hardening@<commit-sha>  # vX.Y.Z
+#     with:
+#       path: .            # optional, default "."
+#       warn-only: "false" # optional; "true" reports without failing the job
+#
+# Pin to a full commit SHA (resolve with:
+#   gh api repos/jordanconway/package-manager-hardening/commits/<tag> --jq .sha
+# ) — never a mutable tag or branch.
+
+name: "Package Manager Hardening Audit"
+description: >-
+  Audit package manager security configuration — lockfiles, exact version
+  pinning, minimum release age, Dependabot cooldowns, Harden-Runner coverage —
+  and fail the job with remediation hints when hardening gaps are found.
+author: "The Linux Foundation"
+
+branding:
+  icon: "shield"
+  color: "green"
+
+inputs:
+  path:
+    description: "Path to the repository root to audit (relative to the workspace)."
+    required: false
+    default: "."
+  warn-only:
+    description: 'Set to "true" to publish the report without failing the job on findings.'
+    required: false
+    default: "false"
+
+outputs:
+  json-path:
+    description: "Absolute path to the raw audit findings JSON (in the runner temp directory)."
+    value: ${{ steps.audit.outputs.json-path }}
+  report-path:
+    description: "Absolute path to the rendered markdown report (in the runner temp directory)."
+    value: ${{ steps.audit.outputs.report-path }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: audit
+      shell: bash
+      # Inputs are passed via env, not interpolated into the script body
+      # (zizmor: template-injection).
+      env:
+        AUDIT_PATH: ${{ inputs.path }}
+        WARN_ONLY: ${{ inputs.warn-only }}
+      run: |
+        audit_json="$RUNNER_TEMP/package-hardening-audit.json"
+        report_md="$RUNNER_TEMP/package-hardening-report.md"
+
+        python3 "$GITHUB_ACTION_PATH/skills/harden-packages/audit.py" \
+          --path "$AUDIT_PATH" --pretty > "$audit_json"
+
+        flags=()
+        if [ "$WARN_ONLY" = "true" ]; then
+          flags+=(--warn-only)
+        fi
+
+        gate=0
+        python3 "$GITHUB_ACTION_PATH/skills/harden-packages/report.py" \
+          "${flags[@]}" "$audit_json" > "$report_md" || gate=$?
+
+        cat "$report_md" >> "$GITHUB_STEP_SUMMARY"
+        cat "$report_md"
+
+        echo "json-path=$audit_json" >> "$GITHUB_OUTPUT"
+        echo "report-path=$report_md" >> "$GITHUB_OUTPUT"
+        exit "$gate"

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -71,10 +71,39 @@ The skill audits all of the following, where applicable to the detected stack:
 
 ## Running the audit in CI (no LLM required)
 
-`audit.py` and its companion `report.py` are stdlib-only, so the audit can run as a plain
-GitHub Actions job with no installation step. `report.py` renders the JSON findings as a
-markdown table with remediation hints (written to the job summary) and exits non-zero on any
-`fail`/`missing` finding, making it usable as a required PR check:
+`audit.py` and its companion `report.py` are stdlib-only, so the audit runs in CI with no
+installation step. `report.py` renders the JSON findings as a markdown table with remediation
+hints (written to the job summary) and exits non-zero on any `fail`/`missing` finding, making
+it usable as a required PR check. `warn` statuses (e.g. documented audit-mode Harden-Runner
+exceptions) never fail the gate.
+
+### As a GitHub Action (recommended)
+
+The repository root carries a composite action ([`action.yml`](../action.yml)) wrapping both
+scripts. In any repo, after your checkout step:
+
+```yaml
+# Resolve <commit-sha> from the release tag:
+#   gh api repos/jordanconway/package-manager-hardening/commits/<tag> --jq .sha
+- uses: jordanconway/package-manager-hardening@<commit-sha> # vX.Y.Z
+  with:
+    path: "."          # repository root to audit (default)
+    warn-only: "false" # "true" reports findings without failing the job
+```
+
+Inputs: `path` (default `"."`), `warn-only` (default `"false"`). Outputs: `json-path` and
+`report-path` — absolute paths (in the runner temp directory, so your workspace stays clean)
+to the raw findings JSON and the rendered markdown, for post-processing or artifact upload.
+Adoption path: start with `warn-only: "true"`, fix the reported findings, then remove it and
+add the job to the branch's required status checks.
+
+This repository dogfoods the action on every PR and weekly via `uses: ./` — see
+[`.github/workflows/self-audit.yml`](../.github/workflows/self-audit.yml).
+
+### Vendored (no cross-repo action reference)
+
+If your policy forbids third-party actions, vendor the two scripts (or the whole skill
+directory) and run them directly:
 
 ```yaml
 - name: Run audit and publish findings
@@ -87,11 +116,7 @@ markdown table with remediation hints (written to the job summary) and exits non
     exit "$gate"
 ```
 
-Pass `--warn-only` to `report.py` to publish the report without gating. `warn` statuses
-(e.g. documented audit-mode Harden-Runner exceptions) never fail the gate. This repository
-runs exactly this job on every PR and weekly — see
-[`.github/workflows/self-audit.yml`](../.github/workflows/self-audit.yml). To adopt it in
-another repo, vendor the two scripts (or the whole skill directory) and copy the workflow.
+Pass `--warn-only` to `report.py` to publish the report without gating.
 
 ## Notes
 

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -69,6 +69,30 @@ The skill audits all of the following, where applicable to the detected stack:
 | Harden-Runner | Present in all workflows, `block` vs `audit` mode, `allowed-endpoints` |
 | Vulnerability scanning | `cargo audit`, `govulncheck`, `pip-audit` in CI |
 
+## Running the audit in CI (no LLM required)
+
+`audit.py` and its companion `report.py` are stdlib-only, so the audit can run as a plain
+GitHub Actions job with no installation step. `report.py` renders the JSON findings as a
+markdown table with remediation hints (written to the job summary) and exits non-zero on any
+`fail`/`missing` finding, making it usable as a required PR check:
+
+```yaml
+- name: Run audit and publish findings
+  run: |
+    python3 skills/harden-packages/audit.py --path . --pretty > audit.json
+    gate=0
+    python3 skills/harden-packages/report.py audit.json > report.md || gate=$?
+    cat report.md >> "$GITHUB_STEP_SUMMARY"
+    cat report.md
+    exit "$gate"
+```
+
+Pass `--warn-only` to `report.py` to publish the report without gating. `warn` statuses
+(e.g. documented audit-mode Harden-Runner exceptions) never fail the gate. This repository
+runs exactly this job on every PR and weekly — see
+[`.github/workflows/self-audit.yml`](../.github/workflows/self-audit.yml). To adopt it in
+another repo, vendor the two scripts (or the whole skill directory) and copy the workflow.
+
 ## Notes
 
 - The skill never downgrades an existing security setting — if you already have a stricter cooldown than the recommended 7 days, it leaves it alone.

--- a/skills/harden-packages/report.py
+++ b/skills/harden-packages/report.py
@@ -79,19 +79,57 @@ HINTS = {
 
 
 def walk(node, path):
-    """Yield (dotted_path, status) for every dict carrying a string status."""
+    """Yield (dotted_path, status, node) for every dict carrying a string status."""
     if not isinstance(node, dict):
         return
     status = node.get("status")
     if isinstance(status, str):
-        yield ".".join(path), status
+        yield ".".join(path), status, node
     if "error" in node and isinstance(node.get("error"), str):
-        yield ".".join(path + ["error"]), "fail"
+        yield ".".join(path + ["error"]), "fail", node
     for key, value in node.items():
         if key == "status":
             continue
         if isinstance(value, dict):
             yield from walk(value, path + [key])
+
+
+def warn_reason(path, node):
+    """Explain why a specific check is a warning, from the finding's own data."""
+    segments = path.split(".")
+
+    if segments[0] == "harden_runner":
+        if len(segments) >= 3 and segments[1] == "workflows":
+            if node.get("egress_policy") == "audit":
+                return (
+                    "Harden-Runner runs in `audit` mode — outbound connections are logged but not blocked. "
+                    "Review the audit log and switch to `egress-policy: block` with an `allowed-endpoints` "
+                    "allowlist. (CodeQL and Scorecard workflows are documented exceptions: both contact "
+                    "endpoint sets too dynamic to allowlist and must stay in audit mode.)"
+                )
+            if node.get("harden_runner_present"):
+                return (
+                    "Harden-Runner is present but its `egress-policy` was not recognised — "
+                    "set it explicitly to `block` (or `audit` while building an allowlist)."
+                )
+            return "Harden-Runner status could not be determined for this workflow."
+        workflows = node.get("workflows")
+        if isinstance(workflows, dict) and workflows:
+            passing = sum(1 for w in workflows.values() if isinstance(w, dict) and w.get("status") == "pass")
+            return (
+                f"{passing} of {len(workflows)} workflows enforce `egress-policy: block`; "
+                "the rest run in audit mode or lack Harden-Runner — see the per-workflow rows."
+            )
+        return "Harden-Runner coverage is incomplete — see the per-workflow rows."
+
+    if segments[0] == "dependabot" and node.get("cooldown_configured") is False:
+        return (
+            "The ecosystem has a dependabot.yml entry but no `cooldown:` block — update PRs are "
+            "raised immediately on release, with no soak time for the community to catch a "
+            "compromised version."
+        )
+
+    return "Configured, but not at the strictest recommended setting — see the linked doc."
 
 
 def hint_for(path):
@@ -123,12 +161,12 @@ def render(report):
 
     lines.append("| Check | Status |")
     lines.append("|-------|--------|")
-    for path, status in checks:
+    for path, status, _node in checks:
         marker = MARKERS.get(status, NEUTRAL_MARKER)
         lines.append(f"| `{path}` | {marker} {status} |")
     lines.append("")
 
-    failing = [(path, status) for path, status in checks if status in FAILING]
+    failing = [(path, status) for path, status, _node in checks if status in FAILING]
     if failing:
         lines.append("## Recommended changes")
         lines.append("")
@@ -138,7 +176,20 @@ def render(report):
             lines.append(f"- `{path}` — {hint_for(path)}{link}")
         lines.append("")
     else:
-        lines.append("No failing checks. ⚠️ items are documented exceptions or pending tightening.")
+        lines.append("No failing checks.")
+        lines.append("")
+
+    warnings = [(path, node) for path, status, node in checks if status == "warn"]
+    if warnings:
+        lines.append("## Warnings explained")
+        lines.append("")
+        lines.append("Warnings never fail this check — they mark documented exceptions or settings")
+        lines.append("that could be tightened further.")
+        lines.append("")
+        for path, node in warnings:
+            doc = doc_for(path)
+            link = f" ([{doc}]({doc}))" if doc else ""
+            lines.append(f"- `{path}` — {warn_reason(path, node)}{link}")
         lines.append("")
 
     return "\n".join(lines), [path for path, _ in failing]

--- a/skills/harden-packages/report.py
+++ b/skills/harden-packages/report.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+#
+# SPDX-License-Identifier: MIT
+
+"""
+report.py — render audit.py findings as a markdown report with a CI gate.
+
+Reads the JSON emitted by audit.py and writes a GitHub-flavoured markdown
+summary to stdout (suitable for $GITHUB_STEP_SUMMARY). Exits non-zero when
+any check reports "fail" or "missing", so it can gate a CI job. Statuses of
+"warn" (e.g. documented audit-mode Harden-Runner exceptions) and "n/a" never
+fail the gate.
+
+Usage:
+    python audit.py --path . | python report.py
+    python report.py audit.json
+    python report.py audit.json --warn-only   # report, but always exit 0
+
+Like audit.py, this script is dependency-free (stdlib only) so it can run in
+CI without installing anything.
+"""
+
+import json
+import sys
+
+MARKERS = {
+    "pass": "✅",
+    "warn": "⚠️",
+    "fail": "❌",
+    "missing": "❌",
+}
+NEUTRAL_MARKER = "⚪"  # n/a, unknown, no_workflows, anything unrecognised
+
+FAILING = {"fail", "missing"}
+
+# Where to send the reader for each top-level section. Checks under an
+# ecosystem inherit its doc; cross-cutting sections have their own.
+SECTION_DOCS = {
+    "nodejs": "docs/nodejs.md",
+    "python": "docs/python.md",
+    "go": "docs/go.md",
+    "rust": "docs/rust.md",
+    "php": "docs/php.md",
+    "ruby": "docs/ruby.md",
+    "dotnet": "docs/dotnet.md",
+    "terraform": "docs/terraform.md",
+    "maven": "docs/jvm.md",
+    "gradle": "docs/jvm.md",
+    "dependabot": "docs/dependabot.md",
+    "harden_runner": "docs/harden-runner.md",
+}
+
+# One-line remediation hints keyed by the check name (last path segment that
+# isn't a per-item key like a workflow filename). Generic on purpose — the
+# full config templates live in SKILL.md and the per-ecosystem docs.
+HINTS = {
+    "lockfile": "Commit the lockfile and enforce it in CI with the strict install command.",
+    "lock_file_opt_in": "Enable RestorePackagesWithLockFile in Directory.Build.props, restore, commit the lockfile.",
+    "exact_pins": "Replace range/floating constraints with exact version pins.",
+    "minimum_release_age": "Configure the package manager's minimum release age (7 days recommended).",
+    "uv_config": "Set exclude-newer in [tool.uv] and require-hashes/verify-hashes in [tool.uv.pip].",
+    "build_script_control": "Restrict which packages may run install scripts (allowlist).",
+    "ci_frozen_install": "Use the frozen/locked install command in CI.",
+    "ci": "Align CI install and audit commands with the recommended configuration.",
+    "ruby_version": "Pin the interpreter via a ruby directive in Gemfile or a .ruby-version file.",
+    "central_package_management": "Adopt Directory.Packages.props with ManagePackageVersionsCentrally.",
+    "source_mapping": "Add <packageSourceMapping> to nuget.config to prevent dependency confusion.",
+    "enforcer_plugin": "Configure maven-enforcer-plugin with banDynamicVersions et al.",
+    "strict_checksums": "Set <checksumPolicy>fail</checksumPolicy> or pass --strict-checksums in CI.",
+    "sca_scanner": "Wire an SCA scanner (Dependency-Check / CycloneDX / OSS Index) into the build.",
+    "dependency_locking": "Enable dependencyLocking with LockMode.STRICT and commit gradle.lockfile.",
+    "dependency_verification": "Commit gradle/verification-metadata.xml with verify-metadata=true.",
+    "wrapper": "Add distributionSha256Sum to gradle-wrapper.properties.",
+    "repository_control": "Set FAIL_ON_PROJECT_REPOS; remove mavenLocal()/jcenter().",
+    "reject_dynamic": "Configure failOnNonReproducibleResolution() or failOnDynamicVersions().",
+    "dependabot": "Add the missing ecosystem entry with a cooldown block to .github/dependabot.yml.",
+    "harden_runner": "Add step-security/harden-runner as the first step of every workflow.",
+}
+
+
+def walk(node, path):
+    """Yield (dotted_path, status) for every dict carrying a string status."""
+    if not isinstance(node, dict):
+        return
+    status = node.get("status")
+    if isinstance(status, str):
+        yield ".".join(path), status
+    if "error" in node and isinstance(node.get("error"), str):
+        yield ".".join(path + ["error"]), "fail"
+    for key, value in node.items():
+        if key == "status":
+            continue
+        if isinstance(value, dict):
+            yield from walk(value, path + [key])
+
+
+def hint_for(path):
+    segments = path.split(".")
+    for segment in reversed(segments):
+        if segment in HINTS:
+            return HINTS[segment]
+    return "See the linked doc for the recommended configuration."
+
+
+def doc_for(path):
+    top = path.split(".")[0]
+    return SECTION_DOCS.get(top)
+
+
+def render(report):
+    """Return (markdown, failing_paths) for an audit.py report dict."""
+    checks = []
+    for top_key, value in report.items():
+        if top_key in ("repo", "ecosystems_detected"):
+            continue
+        checks.extend(walk(value, [top_key]))
+
+    lines = ["# Package hardening self-audit", ""]
+    detected = report.get("ecosystems_detected")
+    if isinstance(detected, list) and detected:
+        lines.append(f"**Ecosystems detected:** {', '.join(str(e) for e in detected)}")
+        lines.append("")
+
+    lines.append("| Check | Status |")
+    lines.append("|-------|--------|")
+    for path, status in checks:
+        marker = MARKERS.get(status, NEUTRAL_MARKER)
+        lines.append(f"| `{path}` | {marker} {status} |")
+    lines.append("")
+
+    failing = [(path, status) for path, status in checks if status in FAILING]
+    if failing:
+        lines.append("## Recommended changes")
+        lines.append("")
+        for path, _status in failing:
+            doc = doc_for(path)
+            link = f" ([{doc}]({doc}))" if doc else ""
+            lines.append(f"- `{path}` — {hint_for(path)}{link}")
+        lines.append("")
+    else:
+        lines.append("No failing checks. ⚠️ items are documented exceptions or pending tightening.")
+        lines.append("")
+
+    return "\n".join(lines), [path for path, _ in failing]
+
+
+def main():
+    args = [a for a in sys.argv[1:] if a != "--warn-only"]
+    warn_only = "--warn-only" in sys.argv[1:]
+
+    try:
+        if args:
+            with open(args[0], encoding="utf-8") as f:
+                report = json.load(f)
+        else:
+            report = json.load(sys.stdin)
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"report.py: cannot read audit JSON: {e}", file=sys.stderr)
+        sys.exit(2)
+
+    if not isinstance(report, dict):
+        print("report.py: audit JSON must be an object", file=sys.stderr)
+        sys.exit(2)
+
+    markdown, failing = render(report)
+    print(markdown)
+
+    if failing and not warn_only:
+        print(f"report.py: {len(failing)} failing check(s): {', '.join(failing)}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+#
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for report.py (markdown rendering + CI gate)."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import report
+
+REPORT_PY = Path(__file__).parent.parent / "skills" / "harden-packages" / "report.py"
+
+
+# ---------------------------------------------------------------------------
+# walk
+# ---------------------------------------------------------------------------
+
+def test_walk_yields_nested_statuses():
+    tree = {
+        "lockfile": {"status": "pass"},
+        "ci": {"status": "fail", "nested": {"status": "warn"}},
+    }
+    found = dict(report.walk(tree, ["nodejs"]))
+    assert found["nodejs.lockfile"] == "pass"
+    assert found["nodejs.ci"] == "fail"
+    assert found["nodejs.ci.nested"] == "warn"
+
+
+def test_walk_reports_error_keys_as_fail():
+    tree = {"error": "boom"}
+    found = dict(report.walk(tree, ["rust"]))
+    assert found["rust.error"] == "fail"
+
+
+def test_walk_ignores_non_dict_and_missing_status():
+    tree = {"manager": "npm", "list": [1, 2], "sub": {"no_status_here": True}}
+    assert list(report.walk(tree, ["nodejs"])) == []
+
+
+# ---------------------------------------------------------------------------
+# render
+# ---------------------------------------------------------------------------
+
+def test_render_all_pass_has_no_recommendations():
+    audit = {
+        "repo": "/x",
+        "ecosystems_detected": ["nodejs"],
+        "nodejs": {"lockfile": {"status": "pass"}},
+    }
+    markdown, failing = report.render(audit)
+    assert failing == []
+    assert "Recommended changes" not in markdown
+    assert "No failing checks" in markdown
+    assert "✅" in markdown
+
+
+def test_render_failures_include_hint_and_doc_link():
+    audit = {
+        "ecosystems_detected": ["python"],
+        "python": {"lockfile": {"status": "fail"}},
+    }
+    markdown, failing = report.render(audit)
+    assert failing == ["python.lockfile"]
+    assert "Recommended changes" in markdown
+    assert "Commit the lockfile" in markdown
+    assert "docs/python.md" in markdown
+
+
+def test_render_missing_counts_as_failing():
+    audit = {
+        "dependabot": {"status": "missing", "ecosystems": {"go": {"status": "missing"}}},
+    }
+    _markdown, failing = report.render(audit)
+    assert "dependabot" in failing
+    assert "dependabot.ecosystems.go" in failing
+
+
+def test_render_warn_and_na_do_not_fail():
+    audit = {
+        "harden_runner": {"status": "warn", "workflows": {"codeql.yml": {"status": "warn"}}},
+        "nodejs": {"build_script_control": {"status": "n/a"}},
+    }
+    markdown, failing = report.render(audit)
+    assert failing == []
+    assert "⚠️" in markdown
+
+
+def test_render_per_workflow_harden_runner_failure_hint():
+    audit = {
+        "harden_runner": {"status": "warn", "workflows": {"release.yml": {"status": "fail"}}},
+    }
+    markdown, failing = report.render(audit)
+    assert failing == ["harden_runner.workflows.release.yml"]
+    assert "step-security/harden-runner" in markdown
+    assert "docs/harden-runner.md" in markdown
+
+
+# ---------------------------------------------------------------------------
+# CLI gate (subprocess: exit codes are the contract the workflow relies on)
+# ---------------------------------------------------------------------------
+
+def run_cli(payload, *flags):
+    return subprocess.run(
+        [sys.executable, str(REPORT_PY), *flags],
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def test_cli_exits_zero_when_clean():
+    payload = json.dumps({"nodejs": {"lockfile": {"status": "pass"}}})
+    result = run_cli(payload)
+    assert result.returncode == 0
+    assert "self-audit" in result.stdout
+
+
+def test_cli_exits_one_on_failure():
+    payload = json.dumps({"nodejs": {"lockfile": {"status": "fail"}}})
+    result = run_cli(payload)
+    assert result.returncode == 1
+    assert "failing check" in result.stderr
+
+
+def test_cli_warn_only_exits_zero_on_failure():
+    payload = json.dumps({"nodejs": {"lockfile": {"status": "fail"}}})
+    result = run_cli(payload, "--warn-only")
+    assert result.returncode == 0
+    assert "Recommended changes" in result.stdout
+
+
+def test_cli_invalid_json_exits_two():
+    result = run_cli("not json{")
+    assert result.returncode == 2
+
+
+def test_cli_non_object_json_exits_two():
+    result = run_cli(json.dumps(["a", "b"]))
+    assert result.returncode == 2
+
+
+def test_cli_reads_file_argument(tmp_path):
+    audit_file = tmp_path / "audit.json"
+    audit_file.write_text(json.dumps({"go": {"lockfile": {"status": "pass"}}}), encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, str(REPORT_PY), str(audit_file)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "go.lockfile" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# End-to-end against audit.py on a synthetic repo
+# ---------------------------------------------------------------------------
+
+def test_end_to_end_with_audit(tmp_path):
+    import audit
+
+    (tmp_path / "package.json").write_text(json.dumps({"dependencies": {"left-pad": "^1.0.0"}}), encoding="utf-8")
+    findings = {
+        "repo": str(tmp_path),
+        "ecosystems_detected": ["nodejs"],
+        "nodejs": audit.audit_nodejs(str(tmp_path)),
+    }
+    markdown, failing = report.render(findings)
+    assert "nodejs.lockfile" in failing  # no lockfile committed
+    assert "nodejs.exact_pins" in failing  # ^1.0.0 is loose
+    assert "Recommended changes" in markdown

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -23,15 +23,22 @@ def test_walk_yields_nested_statuses():
         "lockfile": {"status": "pass"},
         "ci": {"status": "fail", "nested": {"status": "warn"}},
     }
-    found = dict(report.walk(tree, ["nodejs"]))
+    found = {path: status for path, status, _node in report.walk(tree, ["nodejs"])}
     assert found["nodejs.lockfile"] == "pass"
     assert found["nodejs.ci"] == "fail"
     assert found["nodejs.ci.nested"] == "warn"
 
 
+def test_walk_yields_the_finding_node():
+    tree = {"lockfile": {"status": "warn", "egress_policy": "audit"}}
+    [(path, _status, node)] = list(report.walk(tree, ["x"]))
+    assert path == "x.lockfile"
+    assert node["egress_policy"] == "audit"
+
+
 def test_walk_reports_error_keys_as_fail():
     tree = {"error": "boom"}
-    found = dict(report.walk(tree, ["rust"]))
+    found = {path: status for path, status, _node in report.walk(tree, ["rust"])}
     assert found["rust.error"] == "fail"
 
 
@@ -86,6 +93,60 @@ def test_render_warn_and_na_do_not_fail():
     markdown, failing = report.render(audit)
     assert failing == []
     assert "⚠️" in markdown
+
+
+# ---------------------------------------------------------------------------
+# Warning explanations
+# ---------------------------------------------------------------------------
+
+def test_audit_mode_harden_runner_warning_explained():
+    audit = {
+        "harden_runner": {
+            "status": "warn",
+            "workflows": {
+                "codeql.yml": {"status": "warn", "harden_runner_present": True, "egress_policy": "audit"},
+                "ci.yml": {"status": "pass", "harden_runner_present": True, "egress_policy": "block"},
+            },
+        },
+    }
+    markdown, failing = report.render(audit)
+    assert failing == []
+    assert "Warnings explained" in markdown
+    assert "Warnings never fail this check" in markdown
+    # per-workflow audit-mode reason, including the documented exceptions
+    assert "`audit` mode" in markdown
+    assert "documented exceptions" in markdown
+    # top-level summary counts passing workflows
+    assert "1 of 2 workflows" in markdown
+    assert "docs/harden-runner.md" in markdown
+
+
+def test_dependabot_missing_cooldown_warning_explained():
+    audit = {
+        "dependabot": {
+            "status": "fail",
+            "ecosystems": {
+                "nodejs": {"status": "warn", "ecosystem_key": "npm", "cooldown_configured": False},
+            },
+        },
+    }
+    markdown, _failing = report.render(audit)
+    assert "no `cooldown:` block" in markdown
+    assert "docs/dependabot.md" in markdown
+
+
+def test_unrecognised_warning_gets_generic_reason():
+    audit = {"nodejs": {"some_new_check": {"status": "warn"}}}
+    markdown, failing = report.render(audit)
+    assert failing == []
+    assert "Warnings explained" in markdown
+    assert "not at the strictest recommended setting" in markdown
+
+
+def test_no_warnings_section_when_all_pass():
+    audit = {"nodejs": {"lockfile": {"status": "pass"}}}
+    markdown, _failing = report.render(audit)
+    assert "Warnings explained" not in markdown
 
 
 def test_render_per_workflow_harden_runner_failure_hint():


### PR DESCRIPTION
## Summary

Two layers in one PR (second commit generalises the first):

1. **A reusable composite action** ([`action.yml`](action.yml) at the repo root) so *any* repository can run the hardening audit as a CI check:

   ```yaml
   - uses: jordanconway/package-manager-hardening@<commit-sha> # vX.Y.Z
     with:
       path: "."
       warn-only: "false"
   ```

   - Wraps `audit.py` + new `report.py` — both stdlib-only, so the action installs nothing and adds zero egress requirements beyond checkout
   - Findings table + per-finding remediation hints (with doc links) land in the job summary; the job fails on any `fail`/`missing` finding
   - `warn-only: "true"` for soft adoption; outputs `json-path` / `report-path` (in `$RUNNER_TEMP`, keeping the consumer workspace clean) for post-processing
   - Inputs passed via env, not template interpolation (zizmor: template-injection) — zizmor reports no findings on the action or workflow

2. **This repo dogfoods it**: [`.github/workflows/self-audit.yml`](.github/workflows/self-audit.yml) runs `uses: ./` on every PR, push to main, and weekly — exercising the exact code path consumers get, and acting as the regression gate discussed earlier (a workflow added without harden-runner, a missing cooldown, a loose pin all fail the check).

### Supporting pieces

- **`skills/harden-packages/report.py`** — renders audit JSON → markdown + exit-code gate. `warn`/`n/a` never gate (documented CodeQL/Scorecard audit-mode exceptions stay green). Exit codes: 0 clean, 1 findings, 2 bad input.
- **`tests/test_report.py`** — 17 tests: render/walk units, CLI exit-code contract, end-to-end with audit.py on a synthetic failing repo (295 total).
- **ci.yml** — ruff coverage extended to report.py.
- **README** Quick start "For CI" section + **docs/skill.md** action-first CI guide (vendored snippet retained for third-party-action-free policies).

### Verified locally

- [x] 295/295 tests; ruff + markdownlint clean
- [x] zizmor `--min-severity=medium` on action.yml + self-audit.yml — no findings
- [x] Composite step simulated with GitHub's env (`GITHUB_ACTION_PATH`, `RUNNER_TEMP`, `GITHUB_OUTPUT`, `GITHUB_STEP_SUMMARY`): gate=0 on this repo, outputs written
- [x] Failing-repo simulation: gating exits 1 listing 5 findings; `warn-only` exits 0

### After merge

- Add `Audit this repo with audit.py` to required status checks on `main`
- The action becomes consumable at the next release tag (consumers pin the tag's commit SHA) — worth noting in the next CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)