### PR TITLE
fix(audit): address real-world findings from lfreleng-actions runs

### DIFF
--- a/skills/harden-packages/audit.py
+++ b/skills/harden-packages/audit.py
@@ -284,28 +284,42 @@ def audit_python(root):
             "note": "requirements.lock from pip-compile --generate-hashes expected",
         }
 
-    # Exact pins in pyproject.toml
+    # Exact pins in pyproject.toml. Scan only the dependency arrays —
+    # [project] dependencies, [project.optional-dependencies], and
+    # [dependency-groups] — never the whole [project] table: keys like
+    # authors = [{ email = "..." }] and requires-python must not be
+    # parsed as package specs.
     if (r / "pyproject.toml").exists():
         content = read(r / "pyproject.toml")
-        # Extract dependencies section lines
         loose = []
-        in_deps = False
+        section = None
+        in_array = False
         for line in content.splitlines():
-            if re.match(r"\[project\.dependencies\]|\[project\]", line):
-                in_deps = True
-            elif line.startswith("[") and in_deps:
-                in_deps = False
-            # requires-python is an interpreter constraint, not a package
-            # dependency — a bounded range there is recommended, not loose.
-            if re.match(r"\s*requires-python\s*=", line):
+            stripped = line.strip()
+            header = re.match(r"\[([^\]]+)\]\s*$", stripped)
+            if header:
+                section = header.group(1)
+                in_array = False
                 continue
-            if in_deps or "dependencies" in line:
-                # Look for lines that have package specs without ==
-                m = re.search(r'"([^"]+[><=!~][^"]*)"', line)
-                if m:
-                    spec = m.group(1)
-                    if not re.search(r"==", spec) and re.search(r"[><=~!]", spec):
-                        loose.append(spec)
+            if not in_array:
+                if section == "project" and re.match(r"dependencies\s*=\s*\[", stripped):
+                    in_array = True
+                elif section in ("project.optional-dependencies", "dependency-groups") and re.match(
+                    r"[\w.-]+\s*=\s*\[", stripped
+                ):
+                    in_array = True
+                if not in_array:
+                    continue
+            for spec in re.findall(r'"([^"]+)"', line) + re.findall(r"'([^']+)'", line):
+                # Loose = has a constraint operator but no exact == pin.
+                # Bare names (no constraint at all) are not flagged here.
+                if "==" not in spec and re.search(r"[><~!]", spec):
+                    loose.append(spec)
+            # Array ends when a ] appears outside quoted strings (extras
+            # markers like "requests[socks]>=2" must not end it early).
+            unquoted = re.sub(r'"[^"]*"', "", re.sub(r"'[^']*'", "", line))
+            if "]" in unquoted:
+                in_array = False
         findings["exact_pins"] = {
             "status": status(len(loose) == 0),
             "loose": loose[:20],
@@ -324,17 +338,47 @@ def audit_python(root):
             "status": status(bool(exclude_newer) and require_hashes and verify_hashes),
         }
 
-    # CI frozen install
+    # CI frozen install — three states:
+    #   pass: frozen installs found and no unfrozen ones
+    #   fail: at least one install command without the frozen/hashes flag
+    #   warn: no install commands at all in workflow files — installs may
+    #         happen inside reusable/composite actions this file-based scan
+    #         cannot see into; verify the frozen flag there manually.
     wfs = workflow_files(root)
     if manager == "uv":
-        pattern = r"uv sync.*--frozen|--frozen.*uv sync"
+        install_re = r"\buv\s+sync\b"
+        frozen_re = r"--frozen"
     else:
-        pattern = r"pip install.*--require-hashes"
-    found_in = [name for name, content in wfs.items() if grep(content, pattern)]
+        install_re = r"\bpip\s+install\b"
+        frozen_re = r"--require-hashes"
+    found_in = []
+    unfrozen_in = []
+    for name, content in wfs.items():
+        for line in content.splitlines():
+            if line.lstrip().startswith("#") or not re.search(install_re, line):
+                continue
+            if re.search(frozen_re, line):
+                if name not in found_in:
+                    found_in.append(name)
+            elif name not in unfrozen_in:
+                unfrozen_in.append(name)
+    if unfrozen_in:
+        ci_status = "fail"
+    elif found_in:
+        ci_status = "pass"
+    else:
+        ci_status = "warn"
     findings["ci_frozen_install"] = {
-        "status": status(bool(found_in)),
+        "status": ci_status,
         "found_in": found_in,
+        "unfrozen_in": unfrozen_in,
     }
+    if ci_status == "warn":
+        findings["ci_frozen_install"]["note"] = (
+            "No install commands found in workflow files. If installs run inside "
+            "reusable or composite actions, this file-based scan cannot see them — "
+            "verify the frozen/hash-checked install flag inside those actions."
+        )
 
     return findings
 
@@ -926,6 +970,13 @@ ECOSYSTEM_KEYS = {
     "dotnet": "nuget",
 }
 
+# Alternative Dependabot ecosystem keys that also satisfy a detected
+# ecosystem — e.g. uv-managed Python repos use `package-ecosystem: "uv"`,
+# not "pip".
+ECOSYSTEM_ALT_KEYS = {
+    "python": ["uv"],
+}
+
 
 def audit_dependabot(root, detected_ecosystems):
     r = Path(root)
@@ -945,7 +996,12 @@ def audit_dependabot(root, detected_ecosystems):
 
     eco_findings = {}
     for eco in detected_ecosystems:
-        key = ECOSYSTEM_KEYS.get(eco, eco)
+        candidate_keys = [ECOSYSTEM_KEYS.get(eco, eco)] + ECOSYSTEM_ALT_KEYS.get(eco, [])
+        key = candidate_keys[0]
+        for candidate in candidate_keys:
+            if grep(content, rf'package-ecosystem:\s*["\']?{re.escape(candidate)}["\']?'):
+                key = candidate
+                break
         present = grep(content, rf'package-ecosystem:\s*["\']?{re.escape(key)}["\']?')
         if present:
             # Check for cooldown block — look for cooldown: within ~10 lines of this ecosystem entry
@@ -996,7 +1052,11 @@ def audit_harden_runner(root):
     for name, content in wfs.items():
         has_hr = grep(content, r"harden-runner")
         egress = find_value(content, r"egress-policy:\s*(\S+)")
-        disable_sudo = grep(content, r"disable-sudo:\s*true")
+        if egress:
+            # YAML values may be quoted ('block', "audit") — normalise so
+            # the pass/warn classification below compares bare words.
+            egress = egress.strip("\"'")
+        disable_sudo = grep(content, r"disable-sudo:\s*[\"']?true[\"']?")
         has_endpoints = grep(content, r"allowed-endpoints")
 
         if not has_hr:

--- a/skills/harden-packages/report.py
+++ b/skills/harden-packages/report.py
@@ -96,6 +96,11 @@ def walk(node, path):
 
 def warn_reason(path, node):
     """Explain why a specific check is a warning, from the finding's own data."""
+    # An explicit note from audit.py is authoritative.
+    note = node.get("note")
+    if isinstance(note, str) and note:
+        return note
+
     segments = path.split(".")
 
     if segments[0] == "harden_runner":

--- a/tests/test_audit_python.py
+++ b/tests/test_audit_python.py
@@ -171,3 +171,126 @@ def test_ci_frozen_install_missing(tmp_path):
     make_workflow(tmp_path, "ci.yml", "steps:\n  - run: pip install -r requirements.txt\n")
     result = audit.audit_python(str(tmp_path))
     assert result["ci_frozen_install"]["status"] == "fail"
+
+
+# ---------------------------------------------------------------------------
+# exact_pins parser scope (lfreleng-actions feedback)
+# ---------------------------------------------------------------------------
+
+def test_authors_not_parsed_as_dependency(tmp_path):
+    # authors = [{ email = "..." }] lives in [project] but is not a
+    # dependency array — the old line-based parser flagged ", email = ".
+    content = (
+        "[project]\n"
+        'name = "x"\n'
+        'authors = [{ name = "Jane Dev", email = "jane@example.org" }]\n'
+        'maintainers = [{ name = "Joe Dev", email = "joe@example.org" }]\n'
+        'dependencies = ["requests==2.31.0"]\n'
+    )
+    (tmp_path / "pyproject.toml").write_text(content)
+    result = audit.audit_python(str(tmp_path))
+    assert result["exact_pins"]["status"] == "pass"
+    assert result["exact_pins"]["loose"] == []
+
+
+def test_loose_dep_in_multiline_array_flagged(tmp_path):
+    content = (
+        "[project]\n"
+        "dependencies = [\n"
+        '  "requests>=2.0.0",\n'
+        '  "httpx==0.25.0",\n'
+        "]\n"
+    )
+    (tmp_path / "pyproject.toml").write_text(content)
+    result = audit.audit_python(str(tmp_path))
+    assert result["exact_pins"]["loose"] == ["requests>=2.0.0"]
+
+
+def test_loose_dep_in_dependency_groups_flagged(tmp_path):
+    content = (
+        "[dependency-groups]\n"
+        "dev = [\n"
+        '  "ruff>=0.11",\n'
+        "]\n"
+    )
+    (tmp_path / "pyproject.toml").write_text(content)
+    result = audit.audit_python(str(tmp_path))
+    assert result["exact_pins"]["status"] == "fail"
+    assert result["exact_pins"]["loose"] == ["ruff>=0.11"]
+
+
+def test_loose_dep_in_optional_dependencies_flagged(tmp_path):
+    content = (
+        "[project.optional-dependencies]\n"
+        'test = ["pytest~=8.0"]\n'
+    )
+    (tmp_path / "pyproject.toml").write_text(content)
+    result = audit.audit_python(str(tmp_path))
+    assert result["exact_pins"]["loose"] == ["pytest~=8.0"]
+
+
+def test_extras_bracket_does_not_end_array(tmp_path):
+    content = (
+        "[project]\n"
+        "dependencies = [\n"
+        '  "requests[socks]==2.31.0",\n'
+        '  "httpx>=0.25.0",\n'
+        "]\n"
+    )
+    (tmp_path / "pyproject.toml").write_text(content)
+    result = audit.audit_python(str(tmp_path))
+    assert result["exact_pins"]["loose"] == ["httpx>=0.25.0"]
+
+
+def test_requires_python_still_not_flagged_with_new_parser(tmp_path):
+    content = (
+        "[project]\n"
+        'requires-python = ">=3.10,<3.15"\n'
+        'dependencies = ["requests==2.31.0"]\n'
+    )
+    (tmp_path / "pyproject.toml").write_text(content)
+    result = audit.audit_python(str(tmp_path))
+    assert result["exact_pins"]["status"] == "pass"
+
+
+# ---------------------------------------------------------------------------
+# CI frozen install — three-state (lfreleng-actions feedback)
+# ---------------------------------------------------------------------------
+
+def test_no_install_commands_warns_with_note(tmp_path):
+    # Installs delegated to a SHA-pinned composite action are invisible to
+    # file-based scanning — that's a warn with an explanation, not a fail.
+    (tmp_path / "uv.lock").write_text("")
+    (tmp_path / "pyproject.toml").write_text("[tool.uv]\n")
+    make_workflow(tmp_path, "ci.yml", "steps:\n  - uses: lfreleng-actions/python-test-action@abc123 # v1\n")
+    result = audit.audit_python(str(tmp_path))
+    assert result["ci_frozen_install"]["status"] == "warn"
+    assert "composite actions" in result["ci_frozen_install"]["note"]
+
+
+def test_unfrozen_uv_sync_fails_and_lists_workflow(tmp_path):
+    (tmp_path / "uv.lock").write_text("")
+    (tmp_path / "pyproject.toml").write_text("[tool.uv]\n")
+    make_workflow(tmp_path, "functional-tests.yaml", "steps:\n  - run: uv sync --all-extras\n")
+    result = audit.audit_python(str(tmp_path))
+    assert result["ci_frozen_install"]["status"] == "fail"
+    assert result["ci_frozen_install"]["unfrozen_in"] == ["functional-tests.yaml"]
+
+
+def test_frozen_and_unfrozen_mix_fails(tmp_path):
+    (tmp_path / "uv.lock").write_text("")
+    (tmp_path / "pyproject.toml").write_text("[tool.uv]\n")
+    make_workflow(tmp_path, "ci.yml", "steps:\n  - run: uv sync --frozen\n")
+    make_workflow(tmp_path, "tests.yml", "steps:\n  - run: uv sync --all-extras\n")
+    result = audit.audit_python(str(tmp_path))
+    assert result["ci_frozen_install"]["status"] == "fail"
+    assert result["ci_frozen_install"]["found_in"] == ["ci.yml"]
+    assert result["ci_frozen_install"]["unfrozen_in"] == ["tests.yml"]
+
+
+def test_commented_install_line_ignored(tmp_path):
+    (tmp_path / "uv.lock").write_text("")
+    (tmp_path / "pyproject.toml").write_text("[tool.uv]\n")
+    make_workflow(tmp_path, "ci.yml", "steps:\n  # - run: uv sync --all-extras\n  - run: uv sync --frozen\n")
+    result = audit.audit_python(str(tmp_path))
+    assert result["ci_frozen_install"]["status"] == "pass"

--- a/tests/test_dependabot.py
+++ b/tests/test_dependabot.py
@@ -129,3 +129,47 @@ def test_dependabot_yaml_extension(tmp_path):
     result = audit.audit_dependabot(str(tmp_path), ["nodejs"])
     assert result["file"] is not None
     assert result["ecosystems"]["nodejs"]["status"] == "pass"
+
+
+# ---------------------------------------------------------------------------
+# uv ecosystem key satisfies python (lfreleng-actions feedback)
+# ---------------------------------------------------------------------------
+
+def test_uv_ecosystem_key_satisfies_python(tmp_path):
+    content = """\
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+"""
+    write_file(tmp_path, ".github/dependabot.yml", content)
+    result = audit.audit_dependabot(str(tmp_path), ["python"])
+    assert result["ecosystems"]["python"]["status"] == "pass"
+    assert result["ecosystems"]["python"]["ecosystem_key"] == "uv"
+    assert result["ecosystems"]["python"]["cooldown_default_days"] == 7
+
+
+def test_uv_ecosystem_without_cooldown_warns(tmp_path):
+    content = """\
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+"""
+    write_file(tmp_path, ".github/dependabot.yml", content)
+    result = audit.audit_dependabot(str(tmp_path), ["python"])
+    assert result["ecosystems"]["python"]["status"] == "warn"
+    assert result["ecosystems"]["python"]["ecosystem_key"] == "uv"
+
+
+def test_pip_key_still_satisfies_python(tmp_path):
+    write_file(tmp_path, ".github/dependabot.yml", DEPENDABOT_FULL)
+    result = audit.audit_dependabot(str(tmp_path), ["python"])
+    assert result["ecosystems"]["python"]["status"] == "pass"
+    assert result["ecosystems"]["python"]["ecosystem_key"] == "pip"

--- a/tests/test_harden_runner.py
+++ b/tests/test_harden_runner.py
@@ -100,3 +100,38 @@ def test_mixed_workflows_one_missing_hr(tmp_path):
     assert result["workflows"]["release.yml"]["status"] == "fail"
     # some have HR, some don't → warn (at least one present)
     assert result["status"] == "warn"
+
+
+# ---------------------------------------------------------------------------
+# Quoted YAML values (lfreleng-actions feedback)
+# ---------------------------------------------------------------------------
+
+def test_quoted_egress_policy_block_passes(tmp_path):
+    content = (
+        "jobs:\n  build:\n    steps:\n"
+        "      - uses: step-security/harden-runner@abc # v2\n"
+        "        with:\n"
+        "          egress-policy: 'block'\n"
+        "          disable-sudo: 'true'\n"
+        "          allowed-endpoints: >\n"
+        "            github.com:443\n"
+    )
+    make_workflow(tmp_path, "ci.yml", content)
+    result = audit.audit_harden_runner(str(tmp_path))
+    wf = result["workflows"]["ci.yml"]
+    assert wf["egress_policy"] == "block"
+    assert wf["disable_sudo"] is True
+    assert wf["status"] == "pass"
+
+
+def test_double_quoted_egress_policy_audit_warns(tmp_path):
+    content = (
+        "jobs:\n  build:\n    steps:\n"
+        "      - uses: step-security/harden-runner@abc # v2\n"
+        "        with:\n"
+        '          egress-policy: "audit"\n'
+    )
+    make_workflow(tmp_path, "ci.yml", content)
+    result = audit.audit_harden_runner(str(tmp_path))
+    assert result["workflows"]["ci.yml"]["egress_policy"] == "audit"
+    assert result["workflows"]["ci.yml"]["status"] == "warn"


### PR DESCRIPTION
## Summary

Running the new audit action ([#51](https://github.com/jordanconway/package-manager-hardening/pull/51)) against `lfreleng-actions/dependamerge` and `lfreleng-actions/lftools-uv` exposed three bugs and a correctness quirk. All four are fixed here, each with regression tests reproducing the reported case.

### 1. `uv` Dependabot ecosystem not recognised
Both repos have a `uv` entry with a 7-day cooldown in dependabot.yml, but the auditor only checked the `pip` key and reported "Dependabot python missing" — a serious under-report for a uv-first org. New `ECOSYSTEM_ALT_KEYS` lets `python` be satisfied by `pip` **or** `uv`; the matched key is surfaced in `ecosystem_key`.

### 2. `authors` parsed as a dependency
The literal `", email = "` appeared in the unpinned list (once in dependamerge, twice in lftools-uv) because the line-based parser treated any quoted string with an operator inside `[project]` as a package spec. The parser now tracks dependency arrays explicitly (`[project] dependencies`, `[project.optional-dependencies]`, `[dependency-groups]`) and ignores everything else. Also fixed en route: extras brackets (`"requests[socks]>=2"`) no longer terminate array tracking early.

### 3. False `ci_frozen_install: fail` with reusable composite actions
Both repos run installs inside SHA-pinned `lfreleng-actions/python-test-action` — file-based scanning of the caller can't see them. Now three-state:
- **fail** only when an install command *without* the frozen/hashes flag is found — workflows listed in new `unfrozen_in` (still catches lftools-uv's bare `uv sync --all-extras` in functional-tests.yaml, the minor true finding)
- **pass** when frozen installs are present
- **warn** with an explanatory `note` when no install commands exist in workflow files at all; report.py prefers a finding's own `note` when explaining warnings, so the action output says exactly why

### 4. Quoted YAML values (correctness, not just cosmetic)
`egress-policy: 'block'` was captured *with* the quotes — so a block-mode repo was classified **warn** instead of pass. Quotes are now stripped, and `disable-sudo: 'true'` is detected.

### Not changed (deliberate)
Bounded ranges like `openstacksdk>=4.0.0,<5.0.0` are still flagged by `exact_pins` — the library-vs-application calibration is queued as a separate `--profile library` follow-up rather than silently changing gate semantics here.

## Verification

- [x] 315/315 tests (+15 regressions covering each reported case)
- [x] ruff check/format clean on audit.py + report.py
- [x] Synthetic reproduction of the two repos: `dependabot python: pass via uv`; no email junk in `loose`; `ci_frozen_install: warn` + note; quoted `'block'` → pass
- [x] Self-audit gate on this repo still clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)