### PR TITLE
fix(audit): recognise harden-runner companion loaders and reusable callers

### DIFF
--- a/skills/harden-packages/audit.py
+++ b/skills/harden-packages/audit.py
@@ -1050,7 +1050,24 @@ def audit_harden_runner(root):
 
     results = {}
     for name, content in wfs.items():
-        has_hr = grep(content, r"harden-runner")
+        # Detect harden-runner from `uses:` references (not bare substring
+        # matches, which counted comments). Companion allow-list loaders
+        # (e.g. lfreleng-actions/harden-runner-block-action) publish an env
+        # var from their pre: hook that step-security/harden-runner's own
+        # pre: hook consumes — pre: hooks run in step order, so the loader
+        # must appear BEFORE the harden-runner step to have any effect.
+        uses_refs = re.findall(r"^\s*(?:-\s*)?uses:\s*(\S+)", content, re.MULTILINE)
+        hr_idx = next((i for i, u in enumerate(uses_refs) if "step-security/harden-runner" in u), None)
+        companion_idx = next(
+            (i for i, u in enumerate(uses_refs) if "harden-runner" in u and "step-security/harden-runner" not in u),
+            None,
+        )
+        has_hr = hr_idx is not None
+        has_steps = grep(content, r"^\s*steps:", re.MULTILINE)
+        # Thin caller of a reusable workflow: job-level `uses:`, no steps —
+        # file-based scanning cannot see inside the called workflow.
+        reusable_call = bool(uses_refs) and not has_steps
+
         egress = find_value(content, r"egress-policy:\s*(\S+)")
         if egress:
             # YAML values may be quoted ('block', "audit") — normalise so
@@ -1059,28 +1076,56 @@ def audit_harden_runner(root):
         disable_sudo = grep(content, r"disable-sudo:\s*[\"']?true[\"']?")
         has_endpoints = grep(content, r"allowed-endpoints")
 
-        if not has_hr:
+        note = None
+        if has_hr:
+            if egress == "audit":
+                wf_status = "warn"
+            elif egress == "block":
+                wf_status = "pass"
+            else:
+                wf_status = "warn"
+            if companion_idx is not None and companion_idx > hr_idx:
+                wf_status = "warn"
+                note = (
+                    "An allow-list loader companion action appears AFTER the "
+                    "step-security/harden-runner step. pre: hooks run in step order, "
+                    "so the loader's env var does not exist when harden-runner's own "
+                    "pre: hook reads allowed-endpoints — move the loader before the "
+                    "harden-runner step."
+                )
+        elif reusable_call:
+            wf_status = "warn"
+            note = (
+                "This workflow only calls a reusable workflow; file-based scanning "
+                "cannot see inside it. Verify the called workflow runs "
+                "step-security/harden-runner (block mode) as its first step."
+            )
+        elif companion_idx is not None:
             wf_status = "fail"
-        elif egress == "audit":
-            wf_status = "warn"
-        elif egress == "block":
-            wf_status = "pass"
+            note = (
+                "An allow-list loader companion action is present but no "
+                "step-security/harden-runner step follows it — the loader alone "
+                "provides no egress control."
+            )
         else:
-            wf_status = "warn"
+            wf_status = "fail"
 
         results[name] = {
             "harden_runner_present": has_hr,
             "egress_policy": egress,
             "disable_sudo": disable_sudo,
             "allowed_endpoints": has_endpoints,
+            "reusable_workflow_call": reusable_call,
             "status": wf_status,
         }
+        if note:
+            results[name]["note"] = note
 
     overall = (
         "pass"
         if all(v["status"] == "pass" for v in results.values())
         else "warn"
-        if any(v["harden_runner_present"] for v in results.values())
+        if any(v["harden_runner_present"] or v["reusable_workflow_call"] for v in results.values())
         else "fail"
     )
 

--- a/tests/test_harden_runner.py
+++ b/tests/test_harden_runner.py
@@ -135,3 +135,88 @@ def test_double_quoted_egress_policy_audit_warns(tmp_path):
     result = audit.audit_harden_runner(str(tmp_path))
     assert result["workflows"]["ci.yml"]["egress_policy"] == "audit"
     assert result["workflows"]["ci.yml"]["status"] == "warn"
+
+
+# ---------------------------------------------------------------------------
+# Companion allow-list loaders + reusable-workflow callers
+# (lfreleng-actions/.github feedback)
+# ---------------------------------------------------------------------------
+
+WF_LOADER_THEN_HR = (
+    "jobs:\n  build:\n    steps:\n"
+    "      - uses: lfreleng-actions/harden-runner-block-action@18d9c44 # v0.1.1\n"
+    "      - uses: step-security/harden-runner@abc # v2\n"
+    "        with:\n"
+    "          egress-policy: block\n"
+    "          allowed-endpoints: ${{ env.CONNECTION_ALLOW_LIST }}\n"
+)
+
+WF_HR_THEN_LOADER = (
+    "jobs:\n  build:\n    steps:\n"
+    "      - uses: step-security/harden-runner@abc # v2\n"
+    "        with:\n"
+    "          egress-policy: block\n"
+    "          allowed-endpoints: ${{ env.CONNECTION_ALLOW_LIST }}\n"
+    "      - uses: lfreleng-actions/harden-runner-block-action@18d9c44 # v0.1.1\n"
+)
+
+WF_LOADER_ONLY = (
+    "jobs:\n  build:\n    steps:\n"
+    "      - uses: lfreleng-actions/harden-runner-block-action@18d9c44 # v0.1.1\n"
+    "      - uses: actions/checkout@abc # v6\n"
+)
+
+WF_REUSABLE_CALLER = (
+    "jobs:\n  audit:\n"
+    "    uses: lfit/releng-reusable-workflows/.github/workflows/reuse-audit.yaml@f43b219 # v0.6.0\n"
+    "    permissions:\n      contents: read\n"
+    "    with:\n      warn_only: true\n"
+)
+
+
+def test_loader_before_harden_runner_block_passes(tmp_path):
+    make_workflow(tmp_path, "ci.yml", WF_LOADER_THEN_HR)
+    result = audit.audit_harden_runner(str(tmp_path))
+    wf = result["workflows"]["ci.yml"]
+    assert wf["status"] == "pass"
+    assert "note" not in wf
+
+
+def test_loader_after_harden_runner_warns_with_ordering_note(tmp_path):
+    make_workflow(tmp_path, "ci.yml", WF_HR_THEN_LOADER)
+    result = audit.audit_harden_runner(str(tmp_path))
+    wf = result["workflows"]["ci.yml"]
+    assert wf["status"] == "warn"
+    assert "pre: hooks run in step order" in wf["note"]
+
+
+def test_loader_without_harden_runner_fails_with_note(tmp_path):
+    make_workflow(tmp_path, "ci.yml", WF_LOADER_ONLY)
+    result = audit.audit_harden_runner(str(tmp_path))
+    wf = result["workflows"]["ci.yml"]
+    assert wf["status"] == "fail"
+    assert "no step-security/harden-runner step" in wf["note"]
+
+
+def test_reusable_workflow_caller_warns_with_note(tmp_path):
+    make_workflow(tmp_path, "package-hardening-audit.yaml", WF_REUSABLE_CALLER)
+    result = audit.audit_harden_runner(str(tmp_path))
+    wf = result["workflows"]["package-hardening-audit.yaml"]
+    assert wf["status"] == "warn"
+    assert wf["harden_runner_present"] is False
+    assert wf["reusable_workflow_call"] is True
+    assert "reusable workflow" in wf["note"]
+    # repo with only thin callers is warn overall, not fail
+    assert result["status"] == "warn"
+
+
+def test_harden_runner_in_comment_only_fails(tmp_path):
+    content = (
+        "jobs:\n  build:\n    steps:\n"
+        "      # TODO: add step-security/harden-runner here\n"
+        "      - uses: actions/checkout@abc # v6\n"
+    )
+    make_workflow(tmp_path, "ci.yml", content)
+    result = audit.audit_harden_runner(str(tmp_path))
+    assert result["workflows"]["ci.yml"]["harden_runner_present"] is False
+    assert result["workflows"]["ci.yml"]["status"] == "fail"


### PR DESCRIPTION
## Summary

Feedback from real-world use in [lfreleng-actions/.github#44](https://github.com/lfreleng-actions/.github/pull/44): the org populates the egress allow-list via `lfreleng-actions/harden-runner-block-action` — a Node action whose `pre:` hook loads a central allow-list into `$CONNECTION_ALLOW_LIST` before `step-security/harden-runner`'s own `pre:` hook reads it — and rolls the audit out through thin callers of a reusable workflow. The audit misreported both patterns.

### Changes to `audit_harden_runner`

1. **`uses:`-based detection.** harden-runner presence is now detected from `uses:` references, not bare substring matches — a `# TODO: add harden-runner` comment no longer counts as present.
2. **Companion-loader ordering validation** (the suggestion from the feedback). `pre:` hooks run in step-definition order, so the loader is only effective *before* the harden-runner step:
   - loader **before** `step-security/harden-runner` + `egress-policy: block` → ✅ pass
   - loader **after** harden-runner → ⚠️ warn with a note explaining the pre-hook ordering and the fix
   - loader present but **no** harden-runner step → ❌ fail with a note (the loader alone provides no egress control)
3. **Thin reusable-workflow callers** (job-level `uses:`, no `steps:`) → ⚠️ warn with a note to verify harden-runner inside the called workflow, instead of ❌ fail. Same treatment as the composite-action blindness fix for `ci_frozen_install` in #52. A repo containing only thin callers is `warn` overall, not `fail`.

All notes surface in the report's "Warnings explained" section via the existing note-first mechanism. Rendered output for the exact lfreleng-actions pattern:

> - `harden_runner.workflows.package-hardening-audit.yaml` — This workflow only calls a reusable workflow; file-based scanning cannot see inside it. Verify the called workflow runs step-security/harden-runner (block mode) as its first step.

## Verification

- [x] 320/320 tests (+5 regressions: loader-first pass, loader-after warn, loader-only fail, thin-caller warn, comment-only fail)
- [x] ruff check/format clean
- [x] Self-audit gate on this repo still clean
- [x] Synthetic reproduction of lfreleng-actions/.github (thin caller + loader/harden-runner two-step): no failures, thin caller explained as ⚠️

🤖 Generated with [Claude Code](https://claude.com/claude-code)