### PR TITLE
fix(report): make doc links absolute URLs to the hardening repo

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,11 @@ runs:
       env:
         AUDIT_PATH: ${{ inputs.path }}
         WARN_ONLY: ${{ inputs.warn-only }}
+        # Pin doc links in the report to the exact ref this action runs at
+        # (the consumer's `@<sha>` / `@vX.Y.Z`), so they match the audit
+        # logic that produced them. Falls back to main for local `uses: ./`.
+        HARDENING_DOC_BASE_URL: >-
+          https://github.com/jordanconway/package-manager-hardening/blob/${{ github.action_ref || 'main' }}/
       run: |
         audit_json="$RUNNER_TEMP/package-hardening-audit.json"
         report_md="$RUNNER_TEMP/package-hardening-report.md"

--- a/skills/harden-packages/report.py
+++ b/skills/harden-packages/report.py
@@ -21,7 +21,15 @@ CI without installing anything.
 """
 
 import json
+import os
 import sys
+
+# Doc links must point at the canonical hardening repo, not the consumer
+# repo the action runs in (where docs/*.md does not exist). The link text
+# stays the readable relative path; the href is absolute. The base is
+# overridable via HARDENING_DOC_BASE_URL so the action can pin docs to the
+# exact version it runs at; it defaults to main.
+DEFAULT_DOC_BASE_URL = "https://github.com/jordanconway/package-manager-hardening/blob/main/"
 
 MARKERS = {
     "pass": "✅",
@@ -150,6 +158,25 @@ def doc_for(path):
     return SECTION_DOCS.get(top)
 
 
+def doc_base_url():
+    base = (os.environ.get("HARDENING_DOC_BASE_URL") or "").strip()
+    if not base:
+        base = DEFAULT_DOC_BASE_URL
+    return base if base.endswith("/") else base + "/"
+
+
+def doc_link(path):
+    """Markdown link to the canonical doc for a finding, or '' if none.
+
+    Link text is the readable relative path; the href is an absolute URL to
+    the hardening repo so it resolves from a consumer repo's CI output.
+    """
+    doc = doc_for(path)
+    if not doc:
+        return ""
+    return f" ([{doc}]({doc_base_url()}{doc}))"
+
+
 def render(report):
     """Return (markdown, failing_paths) for an audit.py report dict."""
     checks = []
@@ -176,9 +203,7 @@ def render(report):
         lines.append("## Recommended changes")
         lines.append("")
         for path, _status in failing:
-            doc = doc_for(path)
-            link = f" ([{doc}]({doc}))" if doc else ""
-            lines.append(f"- `{path}` — {hint_for(path)}{link}")
+            lines.append(f"- `{path}` — {hint_for(path)}{doc_link(path)}")
         lines.append("")
     else:
         lines.append("No failing checks.")
@@ -192,9 +217,7 @@ def render(report):
         lines.append("that could be tightened further.")
         lines.append("")
         for path, node in warnings:
-            doc = doc_for(path)
-            link = f" ([{doc}]({doc}))" if doc else ""
-            lines.append(f"- `{path}` — {warn_reason(path, node)}{link}")
+            lines.append(f"- `{path}` — {warn_reason(path, node)}{doc_link(path)}")
         lines.append("")
 
     return "\n".join(lines), [path for path, _ in failing]

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -73,7 +73,46 @@ def test_render_failures_include_hint_and_doc_link():
     assert failing == ["python.lockfile"]
     assert "Recommended changes" in markdown
     assert "Commit the lockfile" in markdown
-    assert "docs/python.md" in markdown
+    # Readable link text plus an absolute href to the canonical repo, so it
+    # resolves from a consumer repo's CI output rather than 404-ing.
+    assert "[docs/python.md](" in markdown
+    assert "https://github.com/jordanconway/package-manager-hardening/blob/main/docs/python.md" in markdown
+
+
+# ---------------------------------------------------------------------------
+# Doc link base URL
+# ---------------------------------------------------------------------------
+
+def test_doc_link_is_absolute_by_default(monkeypatch):
+    monkeypatch.delenv("HARDENING_DOC_BASE_URL", raising=False)
+    link = report.doc_link("nodejs.lockfile")
+    assert link == (
+        " ([docs/nodejs.md]"
+        "(https://github.com/jordanconway/package-manager-hardening/blob/main/docs/nodejs.md))"
+    )
+
+
+def test_doc_link_respects_base_url_override(monkeypatch):
+    monkeypatch.setenv(
+        "HARDENING_DOC_BASE_URL",
+        "https://github.com/jordanconway/package-manager-hardening/blob/v0.4.1/",
+    )
+    link = report.doc_link("harden_runner.workflows.ci.yml")
+    assert "blob/v0.4.1/docs/harden-runner.md" in link
+
+
+def test_doc_link_normalises_missing_trailing_slash(monkeypatch):
+    monkeypatch.setenv("HARDENING_DOC_BASE_URL", "https://example.test/x")
+    assert report.doc_link("python.lockfile") == " ([docs/python.md](https://example.test/x/docs/python.md))"
+
+
+def test_doc_link_blank_override_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("HARDENING_DOC_BASE_URL", "   ")
+    assert "blob/main/docs/python.md" in report.doc_link("python.lockfile")
+
+
+def test_doc_link_empty_for_unknown_section():
+    assert report.doc_link("mystery.check") == ""
 
 
 def test_render_missing_counts_as_failing():


### PR DESCRIPTION
## Summary

Spotted in a real consumer run ([lfreleng-actions/python-nss-ng CI](https://github.com/lfreleng-actions/python-nss-ng/actions/runs/27435843928?pr=156)): the report's doc links were relative (`docs/python.md`), so they resolved against the **consumer's** repo — where `docs/*.md` doesn't exist — and 404'd.

### Fix
- `report.py` now emits an absolute href to `jordanconway/package-manager-hardening`, keeping the readable relative path as the link *text*: `[docs/python.md](https://github.com/jordanconway/package-manager-hardening/blob/main/docs/python.md)`.
- Base URL is overridable via `HARDENING_DOC_BASE_URL` (defaults to `main`). `action.yml` sets it from `github.action_ref`, so links **pin to the exact ref the action runs at** (`@vX.Y.Z` / `@<sha>`) and match the audit logic that produced them; falls back to `main` for local `uses: ./`.

### Verification
- [x] 325/325 tests (+5: absolute-by-default, override, trailing-slash normalisation, blank-override fallback, unknown-section empty)
- [x] ruff clean; zizmor clean on action.yml
- [x] Live: default → `blob/main/...`; `HARDENING_DOC_BASE_URL=...blob/v0.4.1/` → `blob/v0.4.1/...`

Worth a v0.4.2 once merged so the org pin picks up resolvable links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)